### PR TITLE
Add repeat/loop syntax for generating multiple structures (Issue #6)

### DIFF
--- a/examples/repeat-schema.xml
+++ b/examples/repeat-schema.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<folder name="%BASE%">
+  <!-- Generate multiple module folders dynamically -->
+  <repeat count="%NUM_MODULES%" as="i">
+    <folder name="module_%i%">
+      <file name="index.ts" />
+      <file name="README.md" />
+    </folder>
+  </repeat>
+
+  <!-- Nested repeat example: 2 groups with 3 items each -->
+  <folder name="data">
+    <repeat count="2" as="group">
+      <folder name="group_%group_1%">
+        <repeat count="3" as="item">
+          <file name="item_%item_1%.json" />
+        </repeat>
+      </folder>
+    </repeat>
+  </folder>
+
+  <!-- Repeat combined with conditionals -->
+  <repeat count="3" as="n">
+    <folder name="chapter_%n_1%">
+      <file name="content.md" />
+      <if var="INCLUDE_TESTS">
+        <file name="test_%n%.spec.ts" />
+      </if>
+    </folder>
+  </repeat>
+
+  <file name="package.json" />
+</folder>

--- a/src-tauri/tests/cli_integration.rs
+++ b/src-tauri/tests/cli_integration.rs
@@ -520,3 +520,480 @@ fn test_quiet_shows_errors() {
     // Errors should still be shown
     assert!(stderr.contains("Error:"));
 }
+
+// ==================== Repeat Feature Tests ====================
+
+/// Schema with repeat block
+const REPEAT_SCHEMA: &str = r#"<folder name="project">
+    <repeat count="3" as="i">
+        <folder name="module_%i%">
+            <file name="index_%i%.ts" />
+        </folder>
+    </repeat>
+</folder>"#;
+
+/// Schema with repeat using 1-based index
+const REPEAT_SCHEMA_1BASED: &str = r#"<folder name="project">
+    <repeat count="2" as="n">
+        <file name="file_%n_1%.txt" />
+    </repeat>
+</folder>"#;
+
+/// Schema with variable-driven repeat count
+const REPEAT_SCHEMA_VAR_COUNT: &str = r#"<folder name="project">
+    <repeat count="%NUM_ITEMS%" as="i">
+        <file name="item_%i%.txt" />
+    </repeat>
+</folder>"#;
+
+/// Schema with nested repeat
+const REPEAT_SCHEMA_NESTED: &str = r#"<folder name="project">
+    <repeat count="2" as="group">
+        <folder name="group_%group%">
+            <repeat count="2" as="item">
+                <file name="item_%item%.txt" />
+            </repeat>
+        </folder>
+    </repeat>
+</folder>"#;
+
+#[test]
+fn test_create_with_repeat() {
+    let temp = TempDir::new().unwrap();
+    let schema_path = create_schema_file(&temp, REPEAT_SCHEMA);
+    let output_dir = temp.path().join("output");
+
+    let output = run_cli(&[
+        "create",
+        "--schema",
+        schema_path.to_str().unwrap(),
+        "--output",
+        output_dir.to_str().unwrap(),
+    ]);
+
+    assert!(output.status.success(), "CLI failed: {}", String::from_utf8_lossy(&output.stderr));
+
+    // Should create 3 module folders (0, 1, 2)
+    assert!(output_dir.join("project/module_0").exists());
+    assert!(output_dir.join("project/module_1").exists());
+    assert!(output_dir.join("project/module_2").exists());
+
+    // Each should have an index file with the iteration number in the filename
+    assert!(output_dir.join("project/module_0/index_0.ts").exists());
+    assert!(output_dir.join("project/module_1/index_1.ts").exists());
+    assert!(output_dir.join("project/module_2/index_2.ts").exists());
+}
+
+#[test]
+fn test_create_with_repeat_1based_index() {
+    let temp = TempDir::new().unwrap();
+    let schema_path = create_schema_file(&temp, REPEAT_SCHEMA_1BASED);
+    let output_dir = temp.path().join("output");
+
+    let output = run_cli(&[
+        "create",
+        "--schema",
+        schema_path.to_str().unwrap(),
+        "--output",
+        output_dir.to_str().unwrap(),
+    ]);
+
+    assert!(output.status.success(), "CLI failed: {}", String::from_utf8_lossy(&output.stderr));
+
+    // Should create files with 1-based naming (1, 2)
+    assert!(output_dir.join("project/file_1.txt").exists());
+    assert!(output_dir.join("project/file_2.txt").exists());
+    // Should NOT have file_0.txt (the variable uses %n_1% which is 1-based)
+    assert!(!output_dir.join("project/file_0.txt").exists());
+}
+
+#[test]
+fn test_create_with_repeat_variable_count() {
+    let temp = TempDir::new().unwrap();
+    let schema_path = create_schema_file(&temp, REPEAT_SCHEMA_VAR_COUNT);
+    let output_dir = temp.path().join("output");
+
+    let output = run_cli(&[
+        "create",
+        "--schema",
+        schema_path.to_str().unwrap(),
+        "--output",
+        output_dir.to_str().unwrap(),
+        "--var",
+        "NUM_ITEMS=4",
+    ]);
+
+    assert!(output.status.success(), "CLI failed: {}", String::from_utf8_lossy(&output.stderr));
+
+    // Should create 4 items (0, 1, 2, 3)
+    assert!(output_dir.join("project/item_0.txt").exists());
+    assert!(output_dir.join("project/item_1.txt").exists());
+    assert!(output_dir.join("project/item_2.txt").exists());
+    assert!(output_dir.join("project/item_3.txt").exists());
+    // Should NOT have item_4
+    assert!(!output_dir.join("project/item_4.txt").exists());
+}
+
+#[test]
+fn test_create_with_nested_repeat() {
+    let temp = TempDir::new().unwrap();
+    let schema_path = create_schema_file(&temp, REPEAT_SCHEMA_NESTED);
+    let output_dir = temp.path().join("output");
+
+    let output = run_cli(&[
+        "create",
+        "--schema",
+        schema_path.to_str().unwrap(),
+        "--output",
+        output_dir.to_str().unwrap(),
+    ]);
+
+    assert!(output.status.success(), "CLI failed: {}", String::from_utf8_lossy(&output.stderr));
+
+    // Should create 2 groups with 2 items each
+    assert!(output_dir.join("project/group_0/item_0.txt").exists());
+    assert!(output_dir.join("project/group_0/item_1.txt").exists());
+    assert!(output_dir.join("project/group_1/item_0.txt").exists());
+    assert!(output_dir.join("project/group_1/item_1.txt").exists());
+}
+
+#[test]
+fn test_create_with_repeat_zero_count() {
+    let temp = TempDir::new().unwrap();
+    let schema = r#"<folder name="project">
+        <repeat count="0" as="i">
+            <file name="item_%i%.txt" />
+        </repeat>
+        <file name="marker.txt" />
+    </folder>"#;
+    let schema_path = create_schema_file(&temp, schema);
+    let output_dir = temp.path().join("output");
+
+    let output = run_cli(&[
+        "create",
+        "--schema",
+        schema_path.to_str().unwrap(),
+        "--output",
+        output_dir.to_str().unwrap(),
+    ]);
+
+    assert!(output.status.success(), "CLI failed: {}", String::from_utf8_lossy(&output.stderr));
+
+    // No items should be created
+    assert!(!output_dir.join("project/item_0.txt").exists());
+    // But the marker file should exist
+    assert!(output_dir.join("project/marker.txt").exists());
+}
+
+#[test]
+fn test_create_with_repeat_invalid_count() {
+    let temp = TempDir::new().unwrap();
+    let schema = r#"<folder name="project">
+        <repeat count="not_a_number" as="i">
+            <file name="item_%i%.txt" />
+        </repeat>
+    </folder>"#;
+    let schema_path = create_schema_file(&temp, schema);
+    let output_dir = temp.path().join("output");
+
+    let output = run_cli(&[
+        "create",
+        "--schema",
+        schema_path.to_str().unwrap(),
+        "--output",
+        output_dir.to_str().unwrap(),
+    ]);
+
+    // Should complete but with error logged
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    // Should log specific error about invalid repeat count
+    assert!(
+        stdout.contains("Invalid repeat count") || stderr.contains("Invalid repeat count"),
+        "Expected 'Invalid repeat count' error. stdout: {}, stderr: {}", stdout, stderr
+    );
+}
+
+#[test]
+fn test_create_with_repeat_negative_count() {
+    let temp = TempDir::new().unwrap();
+    let schema_path = create_schema_file(&temp, REPEAT_SCHEMA_VAR_COUNT);
+    let output_dir = temp.path().join("output");
+
+    let output = run_cli(&[
+        "create",
+        "--schema",
+        schema_path.to_str().unwrap(),
+        "--output",
+        output_dir.to_str().unwrap(),
+        "--var",
+        "NUM_ITEMS=-5",
+    ]);
+
+    // Should log an error about negative count
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.contains("cannot be negative") || stderr.contains("cannot be negative"),
+        "Expected 'cannot be negative' error. stdout: {}, stderr: {}", stdout, stderr
+    );
+}
+
+#[test]
+fn test_create_with_repeat_at_max_count() {
+    // Test that exactly MAX_REPEAT_COUNT (10000) is accepted
+    // Use dry-run with JSON output to verify the logs
+    let temp = TempDir::new().unwrap();
+    let schema = r#"<folder name="project">
+        <repeat count="10000" as="i">
+            <file name="item_%i%.txt" />
+        </repeat>
+    </folder>"#;
+    let schema_path = create_schema_file(&temp, schema);
+    let output_dir = temp.path().join("output");
+
+    let output = run_cli(&[
+        "create",
+        "--schema",
+        schema_path.to_str().unwrap(),
+        "--output",
+        output_dir.to_str().unwrap(),
+        "--dry-run",
+        "--json",
+    ]);
+
+    assert!(output.status.success(), "CLI failed: {}", String::from_utf8_lossy(&output.stderr));
+
+    // Should NOT contain any error about exceeding maximum
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stdout.contains("exceeds maximum") && !stderr.contains("exceeds maximum"),
+        "Should accept exactly 10000. stdout: {}, stderr: {}", stdout, stderr
+    );
+
+    // JSON output should show the repeat operation with 10000 count
+    assert!(
+        stdout.contains("10000") && stdout.contains("Would repeat"),
+        "Should show dry-run message for 10000 iterations in JSON. stdout: {}", stdout
+    );
+}
+
+#[test]
+fn test_create_with_repeat_exceeds_max_count() {
+    let temp = TempDir::new().unwrap();
+    let schema = r#"<folder name="project">
+        <repeat count="10001" as="i">
+            <file name="item_%i%.txt" />
+        </repeat>
+    </folder>"#;
+    let schema_path = create_schema_file(&temp, schema);
+    let output_dir = temp.path().join("output");
+
+    let output = run_cli(&[
+        "create",
+        "--schema",
+        schema_path.to_str().unwrap(),
+        "--output",
+        output_dir.to_str().unwrap(),
+    ]);
+
+    // Should log an error about exceeding maximum
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.contains("exceeds maximum") || stderr.contains("exceeds maximum"),
+        "Expected 'exceeds maximum' error. stdout: {}, stderr: {}", stdout, stderr
+    );
+}
+
+#[test]
+fn test_create_with_repeat_empty_as_variable() {
+    let temp = TempDir::new().unwrap();
+    let schema = r#"<folder name="project">
+        <repeat count="3" as="">
+            <file name="item.txt" />
+        </repeat>
+    </folder>"#;
+    let schema_path = create_schema_file(&temp, schema);
+    let output_dir = temp.path().join("output");
+
+    let output = run_cli(&[
+        "create",
+        "--schema",
+        schema_path.to_str().unwrap(),
+        "--output",
+        output_dir.to_str().unwrap(),
+    ]);
+
+    // Should log an error about invalid variable name
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.contains("Invalid repeat variable name") || stderr.contains("Invalid repeat variable name"),
+        "Expected 'Invalid repeat variable name' error. stdout: {}, stderr: {}", stdout, stderr
+    );
+}
+
+#[test]
+fn test_create_with_repeat_numeric_as_variable() {
+    let temp = TempDir::new().unwrap();
+    let schema = r#"<folder name="project">
+        <repeat count="3" as="123">
+            <file name="item_%123%.txt" />
+        </repeat>
+    </folder>"#;
+    let schema_path = create_schema_file(&temp, schema);
+    let output_dir = temp.path().join("output");
+
+    let output = run_cli(&[
+        "create",
+        "--schema",
+        schema_path.to_str().unwrap(),
+        "--output",
+        output_dir.to_str().unwrap(),
+    ]);
+
+    // Should log an error about variable name starting with digit
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.contains("Invalid repeat variable name") || stderr.contains("Invalid repeat variable name"),
+        "Expected error about invalid variable name. stdout: {}, stderr: {}", stdout, stderr
+    );
+}
+
+#[test]
+fn test_create_with_repeat_inside_if_block() {
+    let temp = TempDir::new().unwrap();
+    let schema = r#"<folder name="project">
+        <if var="CREATE_ITEMS">
+            <repeat count="2" as="i">
+                <file name="item_%i%.txt" />
+            </repeat>
+        </if>
+        <file name="marker.txt" />
+    </folder>"#;
+    let schema_path = create_schema_file(&temp, schema);
+    let output_dir = temp.path().join("output");
+
+    // Test with condition true
+    let output = run_cli(&[
+        "create",
+        "--schema",
+        schema_path.to_str().unwrap(),
+        "--output",
+        output_dir.to_str().unwrap(),
+        "--var",
+        "CREATE_ITEMS=true",
+    ]);
+
+    assert!(output.status.success(), "CLI failed: {}", String::from_utf8_lossy(&output.stderr));
+
+    // Items should be created when condition is true
+    assert!(output_dir.join("project/item_0.txt").exists());
+    assert!(output_dir.join("project/item_1.txt").exists());
+    assert!(output_dir.join("project/marker.txt").exists());
+}
+
+#[test]
+fn test_create_with_repeat_inside_if_block_false() {
+    let temp = TempDir::new().unwrap();
+    let schema = r#"<folder name="project">
+        <if var="CREATE_ITEMS">
+            <repeat count="2" as="i">
+                <file name="item_%i%.txt" />
+            </repeat>
+        </if>
+        <file name="marker.txt" />
+    </folder>"#;
+    let schema_path = create_schema_file(&temp, schema);
+    let output_dir = temp.path().join("output");
+
+    // Test with condition false (not provided)
+    let output = run_cli(&[
+        "create",
+        "--schema",
+        schema_path.to_str().unwrap(),
+        "--output",
+        output_dir.to_str().unwrap(),
+    ]);
+
+    assert!(output.status.success(), "CLI failed: {}", String::from_utf8_lossy(&output.stderr));
+
+    // Items should NOT be created when condition is false
+    assert!(!output_dir.join("project/item_0.txt").exists());
+    assert!(!output_dir.join("project/item_1.txt").exists());
+    // But marker should still exist
+    assert!(output_dir.join("project/marker.txt").exists());
+}
+
+#[test]
+fn test_create_with_if_inside_repeat_block() {
+    let temp = TempDir::new().unwrap();
+    let schema = r#"<folder name="project">
+        <repeat count="2" as="i">
+            <folder name="module_%i%">
+                <if var="ADD_README">
+                    <file name="README.md" />
+                </if>
+                <file name="index.ts" />
+            </folder>
+        </repeat>
+    </folder>"#;
+    let schema_path = create_schema_file(&temp, schema);
+    let output_dir = temp.path().join("output");
+
+    let output = run_cli(&[
+        "create",
+        "--schema",
+        schema_path.to_str().unwrap(),
+        "--output",
+        output_dir.to_str().unwrap(),
+        "--var",
+        "ADD_README=true",
+    ]);
+
+    assert!(output.status.success(), "CLI failed: {}", String::from_utf8_lossy(&output.stderr));
+
+    // Both modules should have README and index
+    assert!(output_dir.join("project/module_0/README.md").exists());
+    assert!(output_dir.join("project/module_0/index.ts").exists());
+    assert!(output_dir.join("project/module_1/README.md").exists());
+    assert!(output_dir.join("project/module_1/index.ts").exists());
+}
+
+#[test]
+fn test_create_with_repeat_variable_name_ending_in_1() {
+    let temp = TempDir::new().unwrap();
+    let schema = r#"<folder name="project">
+        <repeat count="2" as="n_1">
+            <file name="item_%n_1%.txt" />
+        </repeat>
+    </folder>"#;
+    let schema_path = create_schema_file(&temp, schema);
+    let output_dir = temp.path().join("output");
+
+    // Use JSON output to capture internal logs
+    let output = run_cli(&[
+        "create",
+        "--schema",
+        schema_path.to_str().unwrap(),
+        "--output",
+        output_dir.to_str().unwrap(),
+        "--json",
+    ]);
+
+    assert!(output.status.success(), "CLI failed: {}", String::from_utf8_lossy(&output.stderr));
+
+    // JSON output should contain the warning about confusing variable name
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("ends with '_1'") || stdout.contains("\"type\":\"warning\""),
+        "Expected warning about confusing variable name in JSON logs. stdout: {}", stdout
+    );
+
+    // Files should still be created correctly
+    assert!(output_dir.join("project/item_0.txt").exists());
+    assert!(output_dir.join("project/item_1.txt").exists());
+}

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -440,3 +440,23 @@ export const LinkIcon = ({ className, size = 24 }: IconProps) => (
     <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
   </svg>
 );
+
+export const RepeatIcon = ({ className, size = 24 }: IconProps) => (
+  <svg
+    className={className}
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <polyline points="17 1 21 5 17 9" />
+    <path d="M3 11V9a4 4 0 0 1 4-4h14" />
+    <polyline points="7 23 3 19 7 15" />
+    <path d="M21 13v2a4 4 0 0 1-4 4H3" />
+  </svg>
+);

--- a/src/components/TreePreview.tsx
+++ b/src/components/TreePreview.tsx
@@ -7,6 +7,7 @@ import {
   GridIcon,
   BranchIcon,
   GitMergeIcon,
+  RepeatIcon,
 } from "./Icons";
 import type { SchemaNode } from "../types/schema";
 import { VisualSchemaEditor } from "./VisualSchemaEditor";
@@ -34,6 +35,7 @@ const TreeItem = ({ node, depth, projectName }: TreeItemProps) => {
   const isFolder = node.type === "folder";
   const isIf = node.type === "if";
   const isElse = node.type === "else";
+  const isRepeat = node.type === "repeat";
   const isConditional = isIf || isElse;
   const hasUrl = !!node.url;
 
@@ -42,6 +44,11 @@ const TreeItem = ({ node, depth, projectName }: TreeItemProps) => {
     ? `if %${node.condition_var || "?"}%`
     : isElse
     ? "else"
+    : null;
+
+  // For repeat nodes, show the count and iteration variable
+  const repeatLabel = isRepeat
+    ? `repeat ${node.repeat_count || "1"} as %${node.repeat_as || "i"}%`
     : null;
 
   // Render children (shared between conditional and non-conditional nodes)
@@ -53,6 +60,24 @@ const TreeItem = ({ node, depth, projectName }: TreeItemProps) => {
       projectName={projectName}
     />
   ));
+
+  // Render repeat block
+  if (isRepeat) {
+    return (
+      <>
+        <div
+          className="flex items-center gap-2 px-2 py-1 rounded-mac cursor-default"
+          style={{ marginLeft: `${depth * INDENT_PX}px` }}
+        >
+          <RepeatIcon size={16} className="text-system-green flex-shrink-0" />
+          <span className="font-mono text-mac-sm font-medium text-system-green">
+            {repeatLabel}
+          </span>
+        </div>
+        {childrenElements}
+      </>
+    );
+  }
 
   return (
     <>

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -37,7 +37,7 @@ const calculateStats = (node: SchemaNode): { folders: number; files: number; dow
       files++;
       if (n.url) downloads++;
     }
-    // if/else are control structures, not counted in stats
+    // if/else/repeat are control structures, not counted in stats
     n.children?.forEach(traverse);
   };
 

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -1,12 +1,47 @@
+/**
+ * Valid node types for schema elements.
+ * - folder: Directory container
+ * - file: File with optional content or URL
+ * - if: Conditional block (renders children when condition_var is truthy)
+ * - else: Alternative block (follows an if block)
+ * - repeat: Loop block (repeats children count times)
+ */
+export const NODE_TYPES = ["folder", "file", "if", "else", "repeat"] as const;
+export type NodeType = (typeof NODE_TYPES)[number];
+
+/**
+ * Represents a single node in the schema tree structure.
+ * Nodes can be files, folders, or control flow elements (if/else/repeat).
+ */
 export interface SchemaNode {
-  id?: string; // Unique ID for tracking during editing
-  type: "folder" | "file" | "if" | "else";
+  /** Unique identifier for tracking during editing and drag-drop operations */
+  id?: string;
+  /** The type of this schema element */
+  type: NodeType;
+  /** Display name (supports variable substitution with %VAR% syntax) */
   name: string;
+  /** URL to download file content from (file nodes only) */
   url?: string;
+  /** Inline file content (file nodes only) */
   content?: string;
+  /** Child nodes (for folder, if, else, repeat types) */
   children?: SchemaNode[];
+  /** Additional XML attributes to preserve during round-trips */
   attributes?: Record<string, string>;
+  /** Variable name to check for conditional rendering (if nodes only, without % delimiters) */
   condition_var?: string;
+  /**
+   * Number of iterations for repeat loops. Can be a literal number or variable reference.
+   * Examples: "3", "%NUM_MODULES%"
+   * @default "1"
+   */
+  repeat_count?: string;
+  /**
+   * Iteration variable name for repeat loops (without % delimiters).
+   * Available inside the loop as %name% (0-indexed) and %name_1% (1-indexed).
+   * @default "i"
+   */
+  repeat_as?: string;
 }
 
 export interface SchemaHooks {

--- a/src/utils/schemaTree.test.ts
+++ b/src/utils/schemaTree.test.ts
@@ -44,6 +44,10 @@ describe("schemaTree utilities", () => {
       expect(canHaveChildren("else")).toBe(true);
     });
 
+    it("returns true for repeat type", () => {
+      expect(canHaveChildren("repeat")).toBe(true);
+    });
+
     it("returns false for file type", () => {
       expect(canHaveChildren("file")).toBe(false);
     });

--- a/src/utils/schemaTree.ts
+++ b/src/utils/schemaTree.ts
@@ -4,7 +4,7 @@ import type { SchemaNode } from "../types/schema";
 export const INDENT_PX = 20;
 
 /** Node types that can contain children */
-const CONTAINER_TYPES = ["folder", "if", "else"] as const;
+const CONTAINER_TYPES = ["folder", "if", "else", "repeat"] as const;
 
 /**
  * Check if a node type can have children

--- a/src/utils/validation.test.ts
+++ b/src/utils/validation.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from "vitest";
+import {
+  sanitizeVariableName,
+  validateVariableName,
+  validateRepeatCount,
+  MAX_REPEAT_COUNT,
+} from "./validation";
+
+describe("validation utilities", () => {
+  describe("sanitizeVariableName", () => {
+    it("returns trimmed value for valid input", () => {
+      expect(sanitizeVariableName("myVar")).toBe("myVar");
+      expect(sanitizeVariableName("  myVar  ")).toBe("myVar");
+    });
+
+    it("strips percent signs", () => {
+      expect(sanitizeVariableName("%myVar%")).toBe("myVar");
+      expect(sanitizeVariableName("%%test%%")).toBe("test");
+    });
+
+    it("removes special characters", () => {
+      expect(sanitizeVariableName("my-var")).toBe("myvar");
+      expect(sanitizeVariableName("my.var")).toBe("myvar");
+      expect(sanitizeVariableName("my var")).toBe("myvar");
+      expect(sanitizeVariableName("my@var!")).toBe("myvar");
+    });
+
+    it("allows alphanumeric and underscore", () => {
+      expect(sanitizeVariableName("my_var_123")).toBe("my_var_123");
+      expect(sanitizeVariableName("_private")).toBe("_private");
+      expect(sanitizeVariableName("123")).toBe("123");
+    });
+
+    it("truncates to 50 characters", () => {
+      const longName = "a".repeat(60);
+      expect(sanitizeVariableName(longName)).toBe("a".repeat(50));
+    });
+
+    it("returns empty string for empty input", () => {
+      expect(sanitizeVariableName("")).toBe("");
+      expect(sanitizeVariableName("   ")).toBe("");
+    });
+  });
+
+  describe("validateVariableName", () => {
+    it("returns null for valid names starting with letter", () => {
+      expect(validateVariableName("i")).toBeNull();
+      expect(validateVariableName("myVar")).toBeNull();
+      expect(validateVariableName("Index")).toBeNull();
+    });
+
+    it("returns null for valid names starting with underscore", () => {
+      expect(validateVariableName("_i")).toBeNull();
+      expect(validateVariableName("_private")).toBeNull();
+      expect(validateVariableName("__double")).toBeNull();
+    });
+
+    it("returns null for empty string (uses default)", () => {
+      expect(validateVariableName("")).toBeNull();
+      expect(validateVariableName("   ")).toBeNull();
+    });
+
+    it("returns error for names starting with digit", () => {
+      expect(validateVariableName("1")).toBe("Variable name cannot start with a digit");
+      expect(validateVariableName("123")).toBe("Variable name cannot start with a digit");
+      expect(validateVariableName("1abc")).toBe("Variable name cannot start with a digit");
+      expect(validateVariableName("0_index")).toBe("Variable name cannot start with a digit");
+    });
+
+    it("allows digits after first character", () => {
+      expect(validateVariableName("var1")).toBeNull();
+      expect(validateVariableName("a123")).toBeNull();
+      expect(validateVariableName("_1")).toBeNull();
+    });
+  });
+
+  describe("validateRepeatCount", () => {
+    it("returns null for valid positive integers", () => {
+      expect(validateRepeatCount("0")).toBeNull();
+      expect(validateRepeatCount("1")).toBeNull();
+      expect(validateRepeatCount("100")).toBeNull();
+      expect(validateRepeatCount("9999")).toBeNull();
+    });
+
+    it("returns null for MAX_REPEAT_COUNT exactly", () => {
+      expect(validateRepeatCount(MAX_REPEAT_COUNT.toString())).toBeNull();
+    });
+
+    it("returns null for empty string (uses default)", () => {
+      expect(validateRepeatCount("")).toBeNull();
+      expect(validateRepeatCount("   ")).toBeNull();
+    });
+
+    it("returns null for valid variable references", () => {
+      expect(validateRepeatCount("%NUM%")).toBeNull();
+      expect(validateRepeatCount("%COUNT%")).toBeNull();
+      expect(validateRepeatCount("%my_var%")).toBeNull();
+      expect(validateRepeatCount("%_private%")).toBeNull();
+      expect(validateRepeatCount("%a1%")).toBeNull();
+    });
+
+    it("returns error for non-integer strings", () => {
+      expect(validateRepeatCount("abc")).toBe("Must be a positive integer or variable reference");
+      expect(validateRepeatCount("1.5")).toBe("Must be a positive integer or variable reference");
+      expect(validateRepeatCount("1e5")).toBe("Must be a positive integer or variable reference");
+    });
+
+    it("returns error for negative numbers", () => {
+      // Note: parseInt("-1") returns -1 which passes the integer check,
+      // so negative numbers get the specific "cannot be negative" error
+      expect(validateRepeatCount("-1")).toBe("Count cannot be negative");
+      expect(validateRepeatCount("-100")).toBe("Count cannot be negative");
+    });
+
+    it("returns error for count exceeding maximum", () => {
+      expect(validateRepeatCount("10001")).toBe(`Count cannot exceed ${MAX_REPEAT_COUNT}`);
+      expect(validateRepeatCount("99999")).toBe(`Count cannot exceed ${MAX_REPEAT_COUNT}`);
+    });
+
+    it("rejects numbers with leading zeros", () => {
+      expect(validateRepeatCount("01")).toBe("Must be a positive integer or variable reference");
+      expect(validateRepeatCount("007")).toBe("Must be a positive integer or variable reference");
+    });
+
+    it("rejects numbers with plus sign", () => {
+      expect(validateRepeatCount("+5")).toBe("Must be a positive integer or variable reference");
+    });
+
+    it("rejects invalid variable references", () => {
+      // Variable starting with digit
+      expect(validateRepeatCount("%1num%")).toBe("Must be a positive integer or variable reference");
+      // Empty variable
+      expect(validateRepeatCount("%%")).toBe("Must be a positive integer or variable reference");
+      // Unclosed variable
+      expect(validateRepeatCount("%NUM")).toBe("Must be a positive integer or variable reference");
+    });
+  });
+});

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,69 @@
+/**
+ * Validation utilities for schema editor inputs.
+ */
+
+/** Maximum allowed repeat count (must match backend MAX_REPEAT_COUNT in lib.rs) */
+export const MAX_REPEAT_COUNT = 10000;
+
+/**
+ * Sanitize variable name: strip %, allow only alphanumeric and underscore, limit length.
+ * Used for both condition variables and repeat iteration variables.
+ */
+export const sanitizeVariableName = (value: string): string => {
+  return value
+    .trim()
+    .replace(/%/g, "") // Strip % signs if user accidentally includes them
+    .replace(/[^a-zA-Z0-9_]/g, "") // Only allow alphanumeric and underscore
+    .slice(0, 50); // Max 50 characters
+};
+
+/**
+ * Validate variable name for use as iteration variable.
+ * Returns null if valid, or an error message string if invalid.
+ *
+ * Iteration variable names must start with a letter or underscore (not a digit).
+ * This is stricter than condition variables which allow any alphanumeric start.
+ *
+ * Note: condition_var (for if blocks) intentionally does NOT apply this validation
+ * because the backend accepts any variable format for conditions. Only repeat_as
+ * (iteration variables) require the leading non-digit constraint.
+ */
+export const validateVariableName = (value: string): string | null => {
+  const trimmed = value.trim();
+  if (!trimmed) return null; // Empty uses default
+
+  const firstChar = trimmed.charAt(0);
+  if (/^[0-9]/.test(firstChar)) {
+    return "Variable name cannot start with a digit";
+  }
+  return null;
+};
+
+/**
+ * Validate repeat count value.
+ * Returns null if valid, or an error message string if invalid.
+ * Valid values: positive integers or variable references like %VAR%
+ */
+export const validateRepeatCount = (value: string): string | null => {
+  const trimmed = value.trim();
+  if (!trimmed) return null; // Empty uses default
+
+  // Check if it's a variable reference (contains %...%)
+  // Variable must start with letter or underscore, followed by alphanumeric/underscore
+  if (/%[A-Za-z_][A-Za-z0-9_]*%/.test(trimmed)) {
+    return null; // Variable references are validated at creation time
+  }
+
+  // Must be a positive integer
+  const num = parseInt(trimmed, 10);
+  if (isNaN(num) || !Number.isInteger(num) || num.toString() !== trimmed) {
+    return "Must be a positive integer or variable reference";
+  }
+  if (num < 0) {
+    return "Count cannot be negative";
+  }
+  if (num > MAX_REPEAT_COUNT) {
+    return `Count cannot exceed ${MAX_REPEAT_COUNT}`;
+  }
+  return null;
+};


### PR DESCRIPTION
Implement <repeat count="N" as="i"> element to generate multiple similar structures dynamically. Features include:

- Rust backend: parse repeat nodes, validate count/variable, expand loops
- Frontend: visual editor support with inline editing of count and variable
- Variable substitution: %i% (0-indexed) and %i_1% (1-indexed)
- Variable count support: count="%NUM_ITEMS%" resolves at creation time
- Validation: MAX_REPEAT_COUNT (10000), no leading digit in variable names
- Warning for confusing variable names ending in _1
- Comprehensive test coverage (15 integration + 21 validation unit tests)

Closes #6 