### PR TITLE
Add template inheritance support (Issue #8)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -86,3 +86,79 @@ Demonstrates variable transformations for case conversion, pluralization, and da
 - `UTILITY_NAME`: `format date`
 - `MODEL_NAME`: `category`
 - `DATE`: `today` (or a date like `2024-01-15`)
+
+### inheritance-schema.xml
+
+Demonstrates template inheritance using the `extends` attribute. Templates can extend other saved templates to reduce duplication:
+
+```xml
+<template extends="base-react-app">
+  <folder name="features">
+    <file name="feature.ts" />
+  </folder>
+</template>
+```
+
+**How it works:**
+
+1. Create and save a base template (e.g., "base-react-app") with common structure
+2. Create a new template that uses `<template extends="base-react-app">`
+3. Add only the additional folders/files specific to this variant
+4. When loaded, the base template's content is merged with the extension
+
+**Features:**
+
+- **Multiple inheritance**: Extend multiple templates with comma separation: `extends="base1, base2"`
+- **Variable inheritance**: Variables from base templates are inherited (child values override base)
+- **Validation inheritance**: Validation rules are inherited and merged (later templates override earlier)
+- **Hooks inheritance**: Post-create hooks from base templates run first, then child hooks
+- **Nested inheritance**: Base templates can themselves extend other templates
+
+**Multiple inheritance merge order:**
+
+When extending multiple templates (`extends="base1, base2"`), they are merged left-to-right:
+- `base1` is resolved first, then `base2`'s children are appended
+- Variables from `base2` override variables from `base1`
+- Validation rules from `base2` completely replace rules from `base1` for the same variable
+
+**Diamond inheritance note:**
+
+If template C extends both A and B, and both A and B extend D, then D's content will appear **twice** in the final result (once via A, once via B). This is by design - use single inheritance chains if you need to avoid duplication.
+
+**Example base template** (save as "base-react-app"):
+
+```xml
+<folder name="%PROJECT%">
+  <file name="package.json" />
+  <file name="README.md" />
+  <folder name="src">
+    <file name="index.tsx" />
+    <file name="App.tsx" />
+  </folder>
+</folder>
+```
+
+**Extending template:**
+
+```xml
+<template extends="base-react-app">
+  <folder name="tests">
+    <file name="App.test.tsx" />
+  </folder>
+  <file name=".gitignore" />
+</template>
+```
+
+**Result after merge:**
+
+```
+%PROJECT%/
+├── package.json      (from base)
+├── README.md         (from base)
+├── src/              (from base)
+│   ├── index.tsx
+│   └── App.tsx
+├── tests/            (from extension)
+│   └── App.test.tsx
+└── .gitignore        (from extension)
+```

--- a/examples/inheritance-schema.xml
+++ b/examples/inheritance-schema.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Template Inheritance Example
+
+  This template extends a base template called "base-react-app".
+  To use this example:
+  1. First, create a template named "base-react-app" with the content below
+  2. Then load this file to see the merged result
+
+  Base template content (save as "base-react-app"):
+
+  <folder name="%PROJECT%">
+    <file name="package.json" />
+    <file name="README.md" />
+    <folder name="src">
+      <file name="index.tsx" />
+      <file name="App.tsx" />
+    </folder>
+    <folder name="public">
+      <file name="index.html" />
+    </folder>
+  </folder>
+-->
+
+<template extends="base-react-app">
+  <!-- These folders/files will be appended to the base template's root.
+       Note: Folders are APPENDED, not merged. This "src" folder below creates
+       a second "src" entry in the tree (it does not merge with the base's "src").
+       The structure creator will create both, effectively combining their contents. -->
+
+  <folder name="src">
+    <folder name="components">
+      <file name="Button.tsx" />
+      <file name="Header.tsx" />
+    </folder>
+
+    <folder name="hooks">
+      <file name="useAuth.ts" />
+    </folder>
+  </folder>
+
+  <folder name="tests">
+    <file name="App.test.tsx" />
+  </folder>
+
+  <file name=".gitignore" />
+</template>

--- a/src-tauri/src/schema.rs
+++ b/src-tauri/src/schema.rs
@@ -1,6 +1,7 @@
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
 use std::io::Read;
 
 /// Default condition variable name for if blocks without an explicit var attribute
@@ -94,10 +95,7 @@ pub fn parse_xml_schema(xml_content: &str) -> Result<SchemaTree, Box<dyn std::er
                 if let Some(node) = parse_element(e)? {
                     // Self-closing tag - add to parent
                     if let Some(parent) = stack.last_mut() {
-                        if parent.children.is_none() {
-                            parent.children = Some(Vec::new());
-                        }
-                        parent.children.as_mut().unwrap().push(node);
+                        parent.children.get_or_insert_with(Vec::new).push(node);
                     } else {
                         root = Some(node);
                     }
@@ -119,10 +117,7 @@ pub fn parse_xml_schema(xml_content: &str) -> Result<SchemaTree, Box<dyn std::er
                     current_hook_text.clear();
                 } else if let Some(node) = stack.pop() {
                     if let Some(parent) = stack.last_mut() {
-                        if parent.children.is_none() {
-                            parent.children = Some(Vec::new());
-                        }
-                        parent.children.as_mut().unwrap().push(node);
+                        parent.children.get_or_insert_with(Vec::new).push(node);
                     } else {
                         root = Some(node);
                     }
@@ -712,6 +707,424 @@ fn build_tree_from_map(
     }
 }
 
+// ============================================================================
+// Template Inheritance Support
+// ============================================================================
+
+/// Maximum depth of template inheritance to prevent runaway recursion.
+/// 10 levels is generous for real-world use cases while preventing stack overflow
+/// from malformed circular dependencies that bypass detection.
+const MAX_INHERITANCE_DEPTH: usize = 10;
+
+/// Validation rule for a variable (frontend API version).
+///
+/// This type mirrors `database::ValidationRule` but uses camelCase serialization
+/// for frontend compatibility. We need both types because:
+/// - `database::ValidationRule`: snake_case for SQLite JSON storage (backwards compatible)
+/// - `schema::ValidationRule`: camelCase for frontend API responses
+///
+/// Use `From<database::ValidationRule>` for easy conversion.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ValidationRule {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pattern: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min_length: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_length: Option<usize>,
+    #[serde(default)]
+    pub required: bool,
+}
+
+impl From<crate::database::ValidationRule> for ValidationRule {
+    fn from(db_rule: crate::database::ValidationRule) -> Self {
+        Self {
+            pattern: db_rule.pattern,
+            min_length: db_rule.min_length,
+            max_length: db_rule.max_length,
+            required: db_rule.required,
+        }
+    }
+}
+
+/// Data returned by the template loader function
+#[derive(Debug, Clone)]
+pub struct TemplateData {
+    pub schema_xml: String,
+    pub variables: HashMap<String, String>,
+    pub variable_validation: HashMap<String, ValidationRule>,
+}
+
+/// Result of parsing a schema with inheritance resolved
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ParseWithInheritanceResult {
+    pub tree: SchemaTree,
+    pub merged_variables: HashMap<String, String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub merged_variable_validation: HashMap<String, ValidationRule>,
+    pub base_templates: Vec<String>,
+}
+
+/// Error types for template inheritance
+#[derive(Debug)]
+pub enum InheritanceError {
+    CircularDependency(Vec<String>),
+    TemplateNotFound(String),
+    MaxDepthExceeded,
+    ParseError(String),
+}
+
+impl std::fmt::Display for InheritanceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            InheritanceError::CircularDependency(chain) => {
+                write!(f, "Circular template dependency detected: {}", chain.join(" -> "))
+            }
+            InheritanceError::TemplateNotFound(name) => {
+                write!(f, "Template '{}' not found", name)
+            }
+            InheritanceError::MaxDepthExceeded => {
+                write!(f, "Maximum inheritance depth ({}) exceeded", MAX_INHERITANCE_DEPTH)
+            }
+            InheritanceError::ParseError(msg) => {
+                write!(f, "Parse error: {}", msg)
+            }
+        }
+    }
+}
+
+impl std::error::Error for InheritanceError {}
+
+/// Extract the `extends` attribute from a `<template>` element if present.
+/// Returns a list of template names to extend (comma-separated).
+pub fn extract_extends_attribute(xml_content: &str) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    let mut reader = Reader::from_str(xml_content);
+    reader.config_mut().trim_text(true);
+
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(ref e)) | Ok(Event::Empty(ref e)) => {
+                let name_bytes = e.name();
+                let tag_name = std::str::from_utf8(name_bytes.as_ref())?;
+
+                if tag_name == "template" {
+                    // Look for extends attribute
+                    for attr in e.attributes() {
+                        let attr = attr?;
+                        let key = std::str::from_utf8(attr.key.as_ref())?;
+                        if key == "extends" {
+                            let value = std::str::from_utf8(&attr.value)?;
+                            // Split by comma and trim whitespace
+                            let extends: Vec<String> = value
+                                .split(',')
+                                .map(|s| s.trim().to_string())
+                                .filter(|s| !s.is_empty())
+                                .collect();
+                            return Ok(extends);
+                        }
+                    }
+                    // Template element found but no extends attribute
+                    return Ok(Vec::new());
+                }
+                // If we hit a non-template element first, no inheritance
+                return Ok(Vec::new());
+            }
+            Ok(Event::Eof) => break,
+            Err(e) => return Err(Box::new(e)),
+            _ => {}
+        }
+    }
+
+    Ok(Vec::new())
+}
+
+/// Parse the children of a `<template>` element (the extension content).
+/// Returns a list of SchemaNodes that should be appended to the base template.
+fn parse_template_children(xml_content: &str) -> Result<(Vec<SchemaNode>, Option<SchemaHooks>), Box<dyn std::error::Error>> {
+    let mut reader = Reader::from_str(xml_content);
+    reader.config_mut().trim_text(true);
+
+    let mut stack: Vec<SchemaNode> = Vec::new();
+    let mut root_children: Vec<SchemaNode> = Vec::new();
+    let mut in_template = false;
+    let mut template_depth = 0;
+    let mut hooks: Option<SchemaHooks> = None;
+    let mut in_hooks = false;
+    let mut current_hook_text = String::new();
+
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(ref e)) => {
+                let name_bytes = e.name();
+                let tag_name = std::str::from_utf8(name_bytes.as_ref())?;
+
+                if tag_name == "template" && !in_template {
+                    in_template = true;
+                    template_depth = 1;
+                    continue;
+                }
+
+                if in_template {
+                    template_depth += 1;
+
+                    if tag_name == "hooks" {
+                        in_hooks = true;
+                        if hooks.is_none() {
+                            hooks = Some(SchemaHooks::default());
+                        }
+                    } else if in_hooks && tag_name == "post-create" {
+                        current_hook_text.clear();
+                    } else if let Some(node) = parse_element(e)? {
+                        stack.push(node);
+                    }
+                }
+            }
+            Ok(Event::Text(ref e)) => {
+                if in_hooks {
+                    current_hook_text.push_str(&e.unescape()?.into_owned());
+                }
+            }
+            Ok(Event::Empty(ref e)) => {
+                if !in_template {
+                    continue;
+                }
+
+                let name_bytes = e.name();
+                let tag_name = std::str::from_utf8(name_bytes.as_ref())?;
+
+                if tag_name == "hooks" || (in_hooks && tag_name == "post-create") {
+                    continue;
+                }
+
+                if let Some(node) = parse_element(e)? {
+                    if let Some(parent) = stack.last_mut() {
+                        parent.children.get_or_insert_with(Vec::new).push(node);
+                    } else {
+                        root_children.push(node);
+                    }
+                }
+            }
+            Ok(Event::End(ref e)) => {
+                let name_bytes = e.name();
+                let tag_name = std::str::from_utf8(name_bytes.as_ref())?;
+
+                if tag_name == "template" && in_template {
+                    template_depth -= 1;
+                    if template_depth == 0 {
+                        in_template = false;
+                    }
+                    continue;
+                }
+
+                if in_template {
+                    template_depth -= 1;
+
+                    if tag_name == "hooks" {
+                        in_hooks = false;
+                    } else if in_hooks && tag_name == "post-create" {
+                        let cmd = current_hook_text.trim().to_string();
+                        if !cmd.is_empty() {
+                            if let Some(ref mut h) = hooks {
+                                h.post_create.push(cmd);
+                            }
+                        }
+                        current_hook_text.clear();
+                    } else if let Some(node) = stack.pop() {
+                        if let Some(parent) = stack.last_mut() {
+                            parent.children.get_or_insert_with(Vec::new).push(node);
+                        } else {
+                            root_children.push(node);
+                        }
+                    }
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(e) => return Err(Box::new(e)),
+            _ => {}
+        }
+    }
+
+    Ok((root_children, hooks))
+}
+
+/// Merge extension children into the base tree's root node.
+fn merge_extension_into_base(base: &mut SchemaNode, extension_children: Vec<SchemaNode>) {
+    if extension_children.is_empty() {
+        return;
+    }
+
+    if let Some(ref mut children) = base.children {
+        children.extend(extension_children);
+    } else {
+        base.children = Some(extension_children);
+    }
+}
+
+/// Merge hooks from extension into base hooks.
+fn merge_hooks(base: Option<SchemaHooks>, extension: Option<SchemaHooks>) -> Option<SchemaHooks> {
+    match (base, extension) {
+        (None, None) => None,
+        (Some(b), None) => Some(b),
+        (None, Some(e)) => Some(e),
+        (Some(mut b), Some(e)) => {
+            b.post_create.extend(e.post_create);
+            Some(b)
+        }
+    }
+}
+
+/// Resolve template inheritance by loading base templates and merging them.
+///
+/// # Arguments
+/// * `xml_content` - The XML content of the template to resolve
+/// * `template_loader` - A function that loads a template by name, returning TemplateData
+///
+/// # Returns
+/// A ParseWithInheritanceResult containing the resolved tree, merged variables/validation, and list of base templates used
+///
+/// # Multiple Inheritance Behavior
+/// When extending multiple templates (`extends="base1, base2"`), only the first base's root node
+/// attributes (name, etc.) are used. Subsequent bases' root attributes are ignored, but their
+/// children are merged. This is intentional to avoid ambiguity about which root "wins".
+pub fn resolve_template_inheritance<F>(
+    xml_content: &str,
+    template_loader: &F,
+) -> Result<ParseWithInheritanceResult, InheritanceError>
+where
+    F: Fn(&str) -> Option<TemplateData>,
+{
+    let mut visited = HashSet::new();
+    let mut base_templates = Vec::new();
+    resolve_inheritance_internal(xml_content, template_loader, &mut visited, &mut base_templates, MAX_INHERITANCE_DEPTH)
+}
+
+fn resolve_inheritance_internal<F>(
+    xml_content: &str,
+    template_loader: &F,
+    visited: &mut HashSet<String>,
+    base_templates: &mut Vec<String>,
+    remaining_depth: usize,
+) -> Result<ParseWithInheritanceResult, InheritanceError>
+where
+    F: Fn(&str) -> Option<TemplateData>,
+{
+    if remaining_depth == 0 {
+        return Err(InheritanceError::MaxDepthExceeded);
+    }
+
+    // Extract extends attribute
+    let extends = extract_extends_attribute(xml_content)
+        .map_err(|e| InheritanceError::ParseError(e.to_string()))?;
+
+    if extends.is_empty() {
+        // No inheritance - just parse normally
+        let tree = parse_xml_schema(xml_content)
+            .map_err(|e| InheritanceError::ParseError(e.to_string()))?;
+        return Ok(ParseWithInheritanceResult {
+            tree,
+            merged_variables: HashMap::new(),
+            merged_variable_validation: HashMap::new(),
+            base_templates: base_templates.clone(),
+        });
+    }
+
+    // We have inheritance to resolve
+    let mut accumulated_root: Option<SchemaNode> = None;
+    let mut accumulated_hooks: Option<SchemaHooks> = None;
+    let mut accumulated_variables: HashMap<String, String> = HashMap::new();
+    let mut accumulated_validation: HashMap<String, ValidationRule> = HashMap::new();
+
+    // Process each base template in order (left to right)
+    for base_name in &extends {
+        // Validate template name
+        let base_name = base_name.trim();
+        if base_name.is_empty() {
+            continue; // Skip empty names (e.g., from "base1,,base2")
+        }
+
+        // Check for circular dependency using the ordered chain for clear error messages
+        if visited.contains(base_name) {
+            // Build chain from base_templates (which preserves order) plus the cycle point
+            let mut chain = base_templates.clone();
+            chain.push(base_name.to_string());
+            return Err(InheritanceError::CircularDependency(chain));
+        }
+
+        // Load the base template
+        let base_data = template_loader(base_name)
+            .ok_or_else(|| InheritanceError::TemplateNotFound(base_name.to_string()))?;
+
+        // Mark as visited before recursing
+        visited.insert(base_name.to_string());
+        base_templates.push(base_name.to_string());
+
+        // Recursively resolve the base template's inheritance
+        let base_result = resolve_inheritance_internal(
+            &base_data.schema_xml,
+            template_loader,
+            visited,
+            base_templates,
+            remaining_depth - 1,
+        )?;
+
+        // Remove from visited after processing (for sibling branches in diamond inheritance)
+        visited.remove(base_name);
+
+        // Merge base variables (earlier bases are overridden by later ones)
+        accumulated_variables.extend(base_data.variables);
+        accumulated_variables.extend(base_result.merged_variables);
+
+        // Merge validation rules (earlier bases are overridden by later ones)
+        accumulated_validation.extend(base_data.variable_validation);
+        accumulated_validation.extend(base_result.merged_variable_validation);
+
+        // Merge base tree
+        if let Some(ref mut acc_root) = accumulated_root {
+            // Append base's children to accumulated root
+            if let Some(base_children) = base_result.tree.root.children {
+                merge_extension_into_base(acc_root, base_children);
+            }
+        } else {
+            accumulated_root = Some(base_result.tree.root);
+        }
+
+        // Merge hooks
+        accumulated_hooks = merge_hooks(accumulated_hooks, base_result.tree.hooks);
+    }
+
+    // Now parse the extension's own children (content inside <template>)
+    let (extension_children, extension_hooks) = parse_template_children(xml_content)
+        .map_err(|e| InheritanceError::ParseError(e.to_string()))?;
+
+    // Merge extension children into accumulated root
+    if let Some(ref mut root) = accumulated_root {
+        merge_extension_into_base(root, extension_children);
+    }
+
+    // Merge extension hooks
+    accumulated_hooks = merge_hooks(accumulated_hooks, extension_hooks);
+
+    // Build final tree
+    let root = accumulated_root.ok_or_else(|| {
+        InheritanceError::ParseError("No root element after inheritance resolution".to_string())
+    })?;
+
+    let stats = calculate_stats(&root);
+
+    Ok(ParseWithInheritanceResult {
+        tree: SchemaTree {
+            root,
+            stats,
+            hooks: accumulated_hooks,
+        },
+        merged_variables: accumulated_variables,
+        merged_variable_validation: accumulated_validation,
+        base_templates: base_templates.clone(),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -950,5 +1363,618 @@ mod tests {
         let repeat_node = &tree.root.children.as_ref().unwrap()[0];
         assert_eq!(repeat_node.repeat_count, Some("%NUM_MODULES%".to_string()));
         assert_eq!(repeat_node.repeat_as, Some("j".to_string()));
+    }
+
+    // ========================================================================
+    // Template Inheritance Tests
+    // ========================================================================
+
+    #[test]
+    fn test_extract_extends_attribute_single() {
+        let xml = r#"<template extends="base-react-app">
+            <folder name="extra" />
+        </template>"#;
+
+        let extends = extract_extends_attribute(xml).unwrap();
+        assert_eq!(extends, vec!["base-react-app"]);
+    }
+
+    #[test]
+    fn test_extract_extends_attribute_multiple() {
+        let xml = r#"<template extends="base1, base2, base3">
+            <folder name="extra" />
+        </template>"#;
+
+        let extends = extract_extends_attribute(xml).unwrap();
+        assert_eq!(extends, vec!["base1", "base2", "base3"]);
+    }
+
+    #[test]
+    fn test_extract_extends_attribute_none() {
+        let xml = r#"<folder name="project">
+            <file name="readme.txt" />
+        </folder>"#;
+
+        let extends = extract_extends_attribute(xml).unwrap();
+        assert!(extends.is_empty());
+    }
+
+    #[test]
+    fn test_extract_extends_template_without_extends() {
+        let xml = r#"<template>
+            <folder name="project" />
+        </template>"#;
+
+        let extends = extract_extends_attribute(xml).unwrap();
+        assert!(extends.is_empty());
+    }
+
+    #[test]
+    fn test_resolve_inheritance_no_extends() {
+        let xml = r#"<folder name="project">
+            <file name="readme.txt" />
+        </folder>"#;
+
+        let loader = |_name: &str| -> Option<TemplateData> {
+            None
+        };
+
+        let result = resolve_template_inheritance(xml, &loader).unwrap();
+        assert_eq!(result.tree.root.name, "project");
+        assert!(result.base_templates.is_empty());
+    }
+
+    #[test]
+    fn test_resolve_inheritance_single_base() {
+        let base_xml = r#"<folder name="%PROJECT%">
+            <file name="package.json" />
+            <folder name="src">
+                <file name="index.ts" />
+            </folder>
+        </folder>"#;
+
+        let extending_xml = r#"<template extends="base-project">
+            <folder name="features">
+                <file name="feature.ts" />
+            </folder>
+        </template>"#;
+
+        let mut base_vars = HashMap::new();
+        base_vars.insert("PROJECT".to_string(), "my-app".to_string());
+
+        let mut base_validation = HashMap::new();
+        base_validation.insert("PROJECT".to_string(), ValidationRule {
+            required: true,
+            ..Default::default()
+        });
+
+        let loader = |name: &str| -> Option<TemplateData> {
+            if name == "base-project" {
+                Some(TemplateData {
+                    schema_xml: base_xml.to_string(),
+                    variables: base_vars.clone(),
+                    variable_validation: base_validation.clone(),
+                })
+            } else {
+                None
+            }
+        };
+
+        let result = resolve_template_inheritance(extending_xml, &loader).unwrap();
+
+        // Root should be from base
+        assert_eq!(result.tree.root.name, "%PROJECT%");
+
+        // Should have base children + extension children
+        let children = result.tree.root.children.as_ref().unwrap();
+        assert_eq!(children.len(), 3); // package.json, src, features
+
+        // Check extension was appended
+        let features = children.iter().find(|c| c.name == "features").unwrap();
+        assert_eq!(features.node_type, "folder");
+
+        // Check variables were inherited
+        assert_eq!(result.merged_variables.get("PROJECT"), Some(&"my-app".to_string()));
+
+        // Check validation rules were inherited
+        assert!(result.merged_variable_validation.get("PROJECT").unwrap().required);
+
+        // Check base templates list
+        assert_eq!(result.base_templates, vec!["base-project"]);
+    }
+
+    #[test]
+    fn test_resolve_inheritance_multiple_bases() {
+        let base1_xml = r#"<folder name="%PROJECT%">
+            <file name="readme.md" />
+        </folder>"#;
+
+        let base2_xml = r#"<folder name="%PROJECT%">
+            <folder name="src" />
+        </folder>"#;
+
+        let extending_xml = r#"<template extends="base1, base2">
+            <file name="extra.txt" />
+        </template>"#;
+
+        let mut base1_vars = HashMap::new();
+        base1_vars.insert("PROJECT".to_string(), "from-base1".to_string());
+
+        let mut base2_vars = HashMap::new();
+        base2_vars.insert("PROJECT".to_string(), "from-base2".to_string());
+        base2_vars.insert("OTHER".to_string(), "value".to_string());
+
+        let loader = |name: &str| -> Option<TemplateData> {
+            match name {
+                "base1" => Some(TemplateData {
+                    schema_xml: base1_xml.to_string(),
+                    variables: base1_vars.clone(),
+                    variable_validation: HashMap::new(),
+                }),
+                "base2" => Some(TemplateData {
+                    schema_xml: base2_xml.to_string(),
+                    variables: base2_vars.clone(),
+                    variable_validation: HashMap::new(),
+                }),
+                _ => None,
+            }
+        };
+
+        let result = resolve_template_inheritance(extending_xml, &loader).unwrap();
+
+        // Should have children from both bases plus extension
+        let children = result.tree.root.children.as_ref().unwrap();
+        assert_eq!(children.len(), 3); // readme.md, src, extra.txt
+
+        // Later base variables override earlier ones
+        assert_eq!(result.merged_variables.get("PROJECT"), Some(&"from-base2".to_string()));
+        assert_eq!(result.merged_variables.get("OTHER"), Some(&"value".to_string()));
+
+        // Both base templates in list
+        assert_eq!(result.base_templates, vec!["base1", "base2"]);
+    }
+
+    #[test]
+    fn test_resolve_inheritance_template_not_found() {
+        let xml = r#"<template extends="nonexistent">
+            <folder name="extra" />
+        </template>"#;
+
+        let loader = |_name: &str| -> Option<TemplateData> {
+            None
+        };
+
+        let result = resolve_template_inheritance(xml, &loader);
+        assert!(matches!(result, Err(InheritanceError::TemplateNotFound(name)) if name == "nonexistent"));
+    }
+
+    #[test]
+    fn test_resolve_inheritance_circular_dependency() {
+        // A extends B, B extends A
+        let template_a = r#"<template extends="template-b">
+            <file name="a.txt" />
+        </template>"#;
+
+        let template_b = r#"<template extends="template-a">
+            <file name="b.txt" />
+        </template>"#;
+
+        let loader = |name: &str| -> Option<TemplateData> {
+            match name {
+                "template-a" => Some(TemplateData {
+                    schema_xml: template_a.to_string(),
+                    variables: HashMap::new(),
+                    variable_validation: HashMap::new(),
+                }),
+                "template-b" => Some(TemplateData {
+                    schema_xml: template_b.to_string(),
+                    variables: HashMap::new(),
+                    variable_validation: HashMap::new(),
+                }),
+                _ => None,
+            }
+        };
+
+        let result = resolve_template_inheritance(template_a, &loader);
+        assert!(matches!(result, Err(InheritanceError::CircularDependency(_))));
+    }
+
+    #[test]
+    fn test_resolve_inheritance_with_hooks() {
+        let base_xml = r#"<folder name="project">
+            <file name="package.json" />
+        </folder>
+        <hooks>
+            <post-create>npm install</post-create>
+        </hooks>"#;
+
+        let extending_xml = r#"<template extends="base">
+            <file name="extra.txt" />
+            <hooks>
+                <post-create>git init</post-create>
+            </hooks>
+        </template>"#;
+
+        let loader = |name: &str| -> Option<TemplateData> {
+            if name == "base" {
+                Some(TemplateData {
+                    schema_xml: base_xml.to_string(),
+                    variables: HashMap::new(),
+                    variable_validation: HashMap::new(),
+                })
+            } else {
+                None
+            }
+        };
+
+        let result = resolve_template_inheritance(extending_xml, &loader).unwrap();
+
+        // Hooks should be merged (base first, then extension)
+        let hooks = result.tree.hooks.unwrap();
+        assert_eq!(hooks.post_create.len(), 2);
+        assert_eq!(hooks.post_create[0], "npm install");
+        assert_eq!(hooks.post_create[1], "git init");
+    }
+
+    #[test]
+    fn test_resolve_inheritance_nested() {
+        // C extends B, B extends A
+        let template_a = r#"<folder name="root">
+            <file name="from-a.txt" />
+        </folder>"#;
+
+        let template_b = r#"<template extends="template-a">
+            <file name="from-b.txt" />
+        </template>"#;
+
+        let template_c = r#"<template extends="template-b">
+            <file name="from-c.txt" />
+        </template>"#;
+
+        let loader = |name: &str| -> Option<TemplateData> {
+            match name {
+                "template-a" => Some(TemplateData {
+                    schema_xml: template_a.to_string(),
+                    variables: HashMap::new(),
+                    variable_validation: HashMap::new(),
+                }),
+                "template-b" => Some(TemplateData {
+                    schema_xml: template_b.to_string(),
+                    variables: HashMap::new(),
+                    variable_validation: HashMap::new(),
+                }),
+                _ => None,
+            }
+        };
+
+        let result = resolve_template_inheritance(template_c, &loader).unwrap();
+
+        // Should have all three files
+        let children = result.tree.root.children.as_ref().unwrap();
+        assert_eq!(children.len(), 3);
+
+        let names: Vec<&str> = children.iter().map(|c| c.name.as_str()).collect();
+        assert!(names.contains(&"from-a.txt"));
+        assert!(names.contains(&"from-b.txt"));
+        assert!(names.contains(&"from-c.txt"));
+
+        // Base templates should include both A and B
+        assert!(result.base_templates.contains(&"template-a".to_string()));
+        assert!(result.base_templates.contains(&"template-b".to_string()));
+    }
+
+    #[test]
+    fn test_resolve_inheritance_empty_template() {
+        // Template with extends but no children
+        let base_xml = r#"<folder name="project">
+            <file name="base.txt" />
+        </folder>"#;
+
+        let extending_xml = r#"<template extends="base"></template>"#;
+
+        let loader = |name: &str| -> Option<TemplateData> {
+            if name == "base" {
+                Some(TemplateData {
+                    schema_xml: base_xml.to_string(),
+                    variables: HashMap::new(),
+                    variable_validation: HashMap::new(),
+                })
+            } else {
+                None
+            }
+        };
+
+        let result = resolve_template_inheritance(extending_xml, &loader).unwrap();
+
+        // Should still have base content
+        assert_eq!(result.tree.root.name, "project");
+        let children = result.tree.root.children.as_ref().unwrap();
+        assert_eq!(children.len(), 1);
+        assert_eq!(children[0].name, "base.txt");
+    }
+
+    #[test]
+    fn test_resolve_inheritance_self_reference() {
+        // Template that tries to extend itself
+        let self_ref = r#"<template extends="myself">
+            <file name="test.txt" />
+        </template>"#;
+
+        let loader = |name: &str| -> Option<TemplateData> {
+            if name == "myself" {
+                Some(TemplateData {
+                    schema_xml: self_ref.to_string(),
+                    variables: HashMap::new(),
+                    variable_validation: HashMap::new(),
+                })
+            } else {
+                None
+            }
+        };
+
+        let result = resolve_template_inheritance(self_ref, &loader);
+        assert!(matches!(result, Err(InheritanceError::CircularDependency(chain)) if chain.contains(&"myself".to_string())));
+    }
+
+    #[test]
+    fn test_resolve_inheritance_empty_extends_values() {
+        // Handles "base1,,base2" gracefully (empty string between commas)
+        let base_xml = r#"<folder name="project">
+            <file name="base.txt" />
+        </folder>"#;
+
+        let extending_xml = r#"<template extends="base, , ">
+            <file name="extra.txt" />
+        </template>"#;
+
+        let loader = |name: &str| -> Option<TemplateData> {
+            if name == "base" {
+                Some(TemplateData {
+                    schema_xml: base_xml.to_string(),
+                    variables: HashMap::new(),
+                    variable_validation: HashMap::new(),
+                })
+            } else {
+                None
+            }
+        };
+
+        let result = resolve_template_inheritance(extending_xml, &loader).unwrap();
+
+        // Should work, ignoring empty names
+        assert_eq!(result.tree.root.name, "project");
+        let children = result.tree.root.children.as_ref().unwrap();
+        assert_eq!(children.len(), 2); // base.txt and extra.txt
+    }
+
+    #[test]
+    fn test_resolve_inheritance_validation_rules_override() {
+        // Child validation rules should override base
+        let base_xml = r#"<folder name="%NAME%">
+            <file name="test.txt" />
+        </folder>"#;
+
+        let extending_xml = r#"<template extends="base">
+            <file name="extra.txt" />
+        </template>"#;
+
+        let mut base_validation = HashMap::new();
+        base_validation.insert("NAME".to_string(), ValidationRule {
+            min_length: Some(3),
+            max_length: Some(10),
+            required: true,
+            ..Default::default()
+        });
+
+        let loader = |name: &str| -> Option<TemplateData> {
+            if name == "base" {
+                Some(TemplateData {
+                    schema_xml: base_xml.to_string(),
+                    variables: HashMap::new(),
+                    variable_validation: base_validation.clone(),
+                })
+            } else {
+                None
+            }
+        };
+
+        let result = resolve_template_inheritance(extending_xml, &loader).unwrap();
+
+        // Base validation should be present (child template doesn't provide its own)
+        let name_validation = result.merged_variable_validation.get("NAME").unwrap();
+        assert_eq!(name_validation.min_length, Some(3));
+        assert_eq!(name_validation.max_length, Some(10));
+        assert!(name_validation.required);
+    }
+
+    #[test]
+    fn test_inheritance_max_depth_exceeded() {
+        // Create a chain of templates that exceeds MAX_INHERITANCE_DEPTH (10)
+        let loader = |name: &str| -> Option<TemplateData> {
+            // Each template extends the next one: level0 -> level1 -> level2 -> ... -> level11
+            let level: usize = name.strip_prefix("level").unwrap_or("0").parse().unwrap_or(0);
+            if level >= 12 {
+                // Base case - no more extends
+                Some(TemplateData {
+                    schema_xml: r#"<folder name="base"><file name="test.txt" /></folder>"#.to_string(),
+                    variables: HashMap::new(),
+                    variable_validation: HashMap::new(),
+                })
+            } else {
+                // Extend the next level
+                Some(TemplateData {
+                    schema_xml: format!(r#"<template extends="level{}"><file name="level{}.txt" /></template>"#, level + 1, level),
+                    variables: HashMap::new(),
+                    variable_validation: HashMap::new(),
+                })
+            }
+        };
+
+        // Start at level 0, which will try to resolve 12 levels deep (exceeding max of 10)
+        let xml = r#"<template extends="level0"><file name="start.txt" /></template>"#;
+        let result = resolve_template_inheritance(xml, &loader);
+
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+        assert!(error.to_string().contains("Maximum inheritance depth"));
+    }
+
+    #[test]
+    fn test_resolve_inheritance_diamond() {
+        // Diamond inheritance: C extends both A and B, and both A and B extend D
+        // This tests that diamond inheritance works but D's content appears twice
+        let template_d = r#"<folder name="root">
+            <file name="from-d.txt" />
+        </folder>"#;
+
+        let template_a = r#"<template extends="template-d">
+            <file name="from-a.txt" />
+        </template>"#;
+
+        let template_b = r#"<template extends="template-d">
+            <file name="from-b.txt" />
+        </template>"#;
+
+        let template_c = r#"<template extends="template-a, template-b">
+            <file name="from-c.txt" />
+        </template>"#;
+
+        let loader = |name: &str| -> Option<TemplateData> {
+            match name {
+                "template-d" => Some(TemplateData {
+                    schema_xml: template_d.to_string(),
+                    variables: HashMap::new(),
+                    variable_validation: HashMap::new(),
+                }),
+                "template-a" => Some(TemplateData {
+                    schema_xml: template_a.to_string(),
+                    variables: HashMap::new(),
+                    variable_validation: HashMap::new(),
+                }),
+                "template-b" => Some(TemplateData {
+                    schema_xml: template_b.to_string(),
+                    variables: HashMap::new(),
+                    variable_validation: HashMap::new(),
+                }),
+                _ => None,
+            }
+        };
+
+        let result = resolve_template_inheritance(template_c, &loader).unwrap();
+
+        // Root should be from template-d (via template-a, which is first in the extends list)
+        assert_eq!(result.tree.root.name, "root");
+
+        // Children: from-d.txt (via A), from-a.txt, from-d.txt (via B), from-b.txt, from-c.txt
+        // Note: D's content appears TWICE because both A and B extend D
+        let children = result.tree.root.children.as_ref().unwrap();
+        let names: Vec<&str> = children.iter().map(|c| c.name.as_str()).collect();
+
+        // D's content appears twice - this is expected behavior for diamond inheritance
+        assert_eq!(names.iter().filter(|&&n| n == "from-d.txt").count(), 2);
+        assert!(names.contains(&"from-a.txt"));
+        assert!(names.contains(&"from-b.txt"));
+        assert!(names.contains(&"from-c.txt"));
+
+        // Base templates should list all in resolution order
+        assert!(result.base_templates.contains(&"template-a".to_string()));
+        assert!(result.base_templates.contains(&"template-b".to_string()));
+        assert!(result.base_templates.contains(&"template-d".to_string()));
+    }
+
+    #[test]
+    fn test_resolve_inheritance_child_overrides_base_validation() {
+        // Test that child template's validation rules override base template's rules
+        let base_xml = r#"<folder name="%NAME%">
+            <file name="test.txt" />
+        </folder>"#;
+
+        let extending_xml = r#"<template extends="base">
+            <file name="extra.txt" />
+        </template>"#;
+
+        let mut base_validation = HashMap::new();
+        base_validation.insert("NAME".to_string(), ValidationRule {
+            min_length: Some(3),
+            max_length: Some(10),
+            required: true,
+            ..Default::default()
+        });
+
+        let loader = |name: &str| -> Option<TemplateData> {
+            if name == "base" {
+                Some(TemplateData {
+                    schema_xml: base_xml.to_string(),
+                    variables: HashMap::new(),
+                    variable_validation: base_validation.clone(),
+                })
+            } else {
+                None
+            }
+        };
+
+        // For this test, we need to simulate a child template with its own validation
+        // Since the extending template XML doesn't carry validation (it comes from the template record),
+        // we test the merging behavior by checking that later validation overrides earlier
+
+        // First verify base-only case works
+        let result = resolve_template_inheritance(extending_xml, &loader).unwrap();
+        let name_validation = result.merged_variable_validation.get("NAME").unwrap();
+        assert_eq!(name_validation.min_length, Some(3));
+        assert_eq!(name_validation.max_length, Some(10));
+        assert!(name_validation.required);
+
+        // Now test with two bases where second overrides first
+        let base1_xml = r#"<folder name="%NAME%">
+            <file name="test.txt" />
+        </folder>"#;
+
+        let base2_xml = r#"<folder name="%NAME%">
+            <file name="other.txt" />
+        </folder>"#;
+
+        let extending_both_xml = r#"<template extends="base1, base2">
+            <file name="extra.txt" />
+        </template>"#;
+
+        let mut base1_validation = HashMap::new();
+        base1_validation.insert("NAME".to_string(), ValidationRule {
+            min_length: Some(3),
+            max_length: Some(10),
+            required: true,
+            ..Default::default()
+        });
+
+        let mut base2_validation = HashMap::new();
+        base2_validation.insert("NAME".to_string(), ValidationRule {
+            min_length: Some(5),  // Override min_length
+            required: false,      // Override required
+            ..Default::default()  // max_length not set
+        });
+
+        let loader2 = |name: &str| -> Option<TemplateData> {
+            match name {
+                "base1" => Some(TemplateData {
+                    schema_xml: base1_xml.to_string(),
+                    variables: HashMap::new(),
+                    variable_validation: base1_validation.clone(),
+                }),
+                "base2" => Some(TemplateData {
+                    schema_xml: base2_xml.to_string(),
+                    variables: HashMap::new(),
+                    variable_validation: base2_validation.clone(),
+                }),
+                _ => None,
+            }
+        };
+
+        let result2 = resolve_template_inheritance(extending_both_xml, &loader2).unwrap();
+        let name_validation2 = result2.merged_variable_validation.get("NAME").unwrap();
+
+        // base2's validation should override base1's (later overrides earlier)
+        assert_eq!(name_validation2.min_length, Some(5));  // From base2
+        assert!(!name_validation2.required);               // From base2
+        // Note: max_length from base1 is lost because base2's entire ValidationRule replaces it
+        assert_eq!(name_validation2.max_length, None);
     }
 }

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -58,6 +58,21 @@ export interface SchemaTree {
   hooks?: SchemaHooks;
 }
 
+/**
+ * Result of parsing a schema with template inheritance resolved.
+ * Returned by cmd_parse_schema_with_inheritance.
+ */
+export interface ParseWithInheritanceResult {
+  /** The fully resolved schema tree with inherited content merged */
+  tree: SchemaTree;
+  /** Variables merged from all base templates (child values override base) */
+  mergedVariables: Record<string, string>;
+  /** Validation rules merged from all base templates (child rules override base) */
+  mergedVariableValidation: Record<string, ValidationRule>;
+  /** List of base template names that were extended (in resolution order) */
+  baseTemplates: string[];
+}
+
 export interface ValidationRule {
   pattern?: string;
   minLength?: number;


### PR DESCRIPTION
Templates can now extend other templates using the `extends` attribute:
- Single inheritance: `<template extends="base-template">`
- Multiple inheritance: `<template extends="base1, base2">`
- Nested inheritance: base templates can extend other templates

Features:
- Variables and validation rules are inherited (child overrides parent)
- Post-create hooks are merged (base hooks run first)
- Circular dependency detection with clear error messages
- Max depth protection (10 levels) to prevent stack overflow
- Diamond inheritance supported (with documented duplication behavior)

Adds new Tauri command `cmd_parse_schema_with_inheritance` that resolves inheritance at parse time, returning the merged tree with inherited variables and validation rules.

Closes #8 