### PR TITLE
Add diff preview for dry run mode (Issue #9)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3509,6 +3509,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3644,6 +3650,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "similar",
  "tar",
  "tauri",
  "tauri-build",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -52,6 +52,8 @@ flate2 = "1.0"
 tempfile = "3"
 # CLI data directory
 dirs = "5"
+# Text diff algorithm
+similar = "2"
 
 [profile.release]
 panic = "abort"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -68,6 +68,120 @@ pub struct ValidationError {
     pub message: String,
 }
 
+// ============================================================================
+// Diff Preview Types
+// ============================================================================
+
+/// Represents the action that would be taken for a filesystem entry
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum DiffAction {
+    /// Item will be created (does not exist)
+    Create,
+    /// Item exists and will be overwritten (when overwrite=true)
+    Overwrite,
+    /// Item exists and will be skipped (when overwrite=false)
+    Skip,
+    /// Folder exists, no action needed (but may contain changed children)
+    Unchanged,
+}
+
+/// Type of diff line
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum DiffLineType {
+    Add,
+    Remove,
+    Context,
+    /// Indicates the diff was truncated (not actual file content)
+    Truncated,
+}
+
+/// Type of node in the diff tree
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum DiffNodeType {
+    Folder,
+    File,
+}
+
+/// A single line in a diff hunk
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiffLine {
+    /// Type of this diff line
+    pub line_type: DiffLineType,
+    /// The line content
+    pub content: String,
+}
+
+/// A diff hunk representing a contiguous block of changes
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiffHunk {
+    /// Line number in old file (1-indexed)
+    pub old_start: usize,
+    /// Number of lines from old file in this hunk
+    pub old_count: usize,
+    /// Line number in new file (1-indexed)
+    pub new_start: usize,
+    /// Number of lines from new file in this hunk
+    pub new_count: usize,
+    /// The diff lines
+    pub lines: Vec<DiffLine>,
+}
+
+/// Represents a file or folder in the diff preview tree
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiffNode {
+    /// Unique identifier for frontend tree navigation
+    pub id: String,
+    /// Type of this node (folder or file)
+    pub node_type: DiffNodeType,
+    /// Display name (with variables substituted)
+    pub name: String,
+    /// Full path relative to output directory
+    pub path: String,
+    /// Action to be taken
+    pub action: DiffAction,
+    /// For files: existing content (if overwriting, truncated for large files)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub existing_content: Option<String>,
+    /// For files: new content to be written (truncated for large files)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub new_content: Option<String>,
+    /// For files: computed diff hunks (for text files only)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diff_hunks: Option<Vec<DiffHunk>>,
+    /// For files with URLs: the source URL
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    /// Whether this is a binary file (no text diff available)
+    #[serde(default)]
+    pub is_binary: bool,
+    /// Child nodes (for folders)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub children: Option<Vec<DiffNode>>,
+}
+
+/// Summary statistics for the diff preview
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiffSummary {
+    pub total_items: usize,
+    pub creates: usize,
+    pub overwrites: usize,
+    pub skips: usize,
+    pub unchanged_folders: usize,
+    /// Warnings generated during diff preview (e.g., invalid repeat counts)
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
+}
+
+/// Complete diff preview result
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiffResult {
+    pub root: DiffNode,
+    pub summary: DiffSummary,
+}
+
 /// Helper to log a repeat-related error and increment error count
 fn log_repeat_error(logs: &mut Vec<LogEntry>, summary: &mut ResultSummary, message: String, details: String) {
     logs.push(LogEntry {
@@ -2593,6 +2707,465 @@ fn cmd_validate_variables(
     Ok(validate_variables(&variables, &rules))
 }
 
+// ============================================================================
+// Diff Preview Implementation
+// ============================================================================
+
+/// Maximum content size to include in diff preview (characters)
+const MAX_DIFF_CONTENT_SIZE: usize = 50000;
+/// Maximum number of lines to show in diff
+const MAX_DIFF_LINES: usize = 1000;
+/// Maximum iterations for repeat blocks in diff preview
+const MAX_REPEAT_ITERATIONS: usize = 100;
+/// Maximum characters to show for condition values in if block names
+const MAX_CONDITION_DISPLAY_LEN: usize = 20;
+/// Truncated display length (leaving room for "...")
+const TRUNCATED_CONDITION_LEN: usize = 17;
+/// Sample size for binary content detection (8KB)
+const BINARY_SAMPLE_SIZE: usize = 8192;
+/// Threshold percentage for binary detection (if >10% non-printable, treat as binary)
+const BINARY_THRESHOLD_DIVISOR: usize = 10;
+
+/// Check if content appears to be binary (contains null bytes or high ratio of non-text bytes)
+fn is_binary_content(content: &[u8]) -> bool {
+    let sample_size = content.len().min(BINARY_SAMPLE_SIZE);
+    let sample = &content[..sample_size];
+
+    // Check for null bytes (common in binary files)
+    if sample.contains(&0) {
+        return true;
+    }
+
+    // Check ratio of non-printable characters (excluding common whitespace)
+    let non_printable = sample.iter()
+        .filter(|&&b| b < 0x20 && b != b'\n' && b != b'\r' && b != b'\t')
+        .count();
+
+    non_printable > sample_size / BINARY_THRESHOLD_DIVISOR
+}
+
+/// Truncate a string at a safe UTF-8 boundary
+fn truncate_utf8(s: &str, max_chars: usize) -> String {
+    if s.chars().count() <= max_chars {
+        return s.to_string();
+    }
+    let truncated: String = s.chars().take(max_chars).collect();
+    format!("{}... (truncated)", truncated)
+}
+
+/// Compute unified diff between old and new content
+fn compute_diff(old_content: &str, new_content: &str) -> Vec<DiffHunk> {
+    use similar::{ChangeTag, TextDiff};
+
+    let diff = TextDiff::from_lines(old_content, new_content);
+    let mut hunks = Vec::new();
+    let mut total_lines = 0;
+
+    'groups: for group in diff.grouped_ops(3) {
+        let mut lines = Vec::new();
+        let mut old_start = 0;
+        let mut old_count = 0;
+        let mut new_start = 0;
+        let mut new_count = 0;
+        let mut first = true;
+
+        for op in group {
+            for change in diff.iter_changes(&op) {
+                // Check limit before adding more lines
+                if total_lines >= MAX_DIFF_LINES {
+                    lines.push(DiffLine {
+                        line_type: DiffLineType::Truncated,
+                        content: "... (diff truncated)".to_string(),
+                    });
+                    // Push current hunk and exit all loops
+                    if !lines.is_empty() {
+                        hunks.push(DiffHunk {
+                            old_start,
+                            old_count,
+                            new_start,
+                            new_count,
+                            lines,
+                        });
+                    }
+                    break 'groups;
+                }
+
+                if first {
+                    old_start = change.old_index().map(|i| i + 1).unwrap_or(1);
+                    new_start = change.new_index().map(|i| i + 1).unwrap_or(1);
+                    first = false;
+                }
+
+                let line_type = match change.tag() {
+                    ChangeTag::Delete => {
+                        old_count += 1;
+                        DiffLineType::Remove
+                    }
+                    ChangeTag::Insert => {
+                        new_count += 1;
+                        DiffLineType::Add
+                    }
+                    ChangeTag::Equal => {
+                        old_count += 1;
+                        new_count += 1;
+                        DiffLineType::Context
+                    }
+                };
+
+                lines.push(DiffLine {
+                    line_type,
+                    content: change.value().to_string(),
+                });
+                total_lines += 1;
+            }
+        }
+
+        if !lines.is_empty() {
+            hunks.push(DiffHunk {
+                old_start,
+                old_count,
+                new_start,
+                new_count,
+                lines,
+            });
+        }
+    }
+
+    hunks
+}
+
+/// Generate a unique ID for diff nodes
+fn generate_diff_id() -> String {
+    uuid::Uuid::new_v4().to_string()
+}
+
+/// Check if a variable value is considered "truthy" for conditional evaluation
+/// Returns the resolved value along with the truthiness result
+fn check_var_truthy(var_name: &str, variables: &HashMap<String, String>) -> (bool, String) {
+    let var_key = format!("%{}%", var_name);
+    let value = variables.get(&var_key)
+        .or_else(|| variables.get(var_name))
+        .cloned()
+        .unwrap_or_default();
+    let is_truthy = !value.is_empty() && value != "0" && value.to_lowercase() != "false";
+    (is_truthy, value)
+}
+
+/// Recursively generate diff nodes for the schema tree
+fn generate_diff_node(
+    node: &SchemaNode,
+    current_path: &PathBuf,
+    variables: &HashMap<String, String>,
+    overwrite: bool,
+    summary: &mut DiffSummary,
+) -> Result<Option<DiffNode>, String> {
+    let schema_node_type = &node.node_type;
+
+    // Handle control flow nodes (if, else, repeat)
+    // NOTE: "if" and "else" cases here are fallbacks for edge cases (e.g., if the root node
+    // is an "if" block). In normal operation, process_diff_children handles these inline
+    // to properly track if/else pairing context.
+    match schema_node_type.as_str() {
+        "if" => {
+            // Fallback handler for "if" nodes not processed by process_diff_children
+            let var_name = node.condition_var.as_deref().unwrap_or("CONDITION");
+            let (is_truthy, resolved_value) = check_var_truthy(var_name, variables);
+
+            if is_truthy {
+                let children = process_diff_children(node, current_path, variables, overwrite, summary)?;
+                if children.is_empty() {
+                    return Ok(None);
+                }
+                let display_value = if resolved_value.chars().count() > MAX_CONDITION_DISPLAY_LEN {
+                    format!("{}...", resolved_value.chars().take(TRUNCATED_CONDITION_LEN).collect::<String>())
+                } else {
+                    resolved_value
+                };
+                return Ok(Some(DiffNode {
+                    id: generate_diff_id(),
+                    node_type: DiffNodeType::Folder,
+                    name: format!("if {} ({})", var_name, display_value),
+                    path: current_path.to_string_lossy().to_string(),
+                    action: DiffAction::Unchanged,
+                    existing_content: None,
+                    new_content: None,
+                    diff_hunks: None,
+                    url: None,
+                    is_binary: false,
+                    children: Some(children),
+                }));
+            }
+            return Ok(None);
+        }
+        "else" => {
+            // Fallback: else blocks without context are skipped (proper handling is in process_diff_children)
+            return Ok(None);
+        }
+        "repeat" => {
+            // Expand repeat blocks
+            let count_str = node.repeat_count.as_deref().unwrap_or("1");
+            let resolved_count_str = substitute_variables(count_str, variables);
+            let count = match resolved_count_str.parse::<usize>() {
+                Ok(n) => {
+                    if n > MAX_REPEAT_ITERATIONS {
+                        summary.warnings.push(format!(
+                            "Repeat count {} exceeds maximum ({}), clamped to {}",
+                            n, MAX_REPEAT_ITERATIONS, MAX_REPEAT_ITERATIONS
+                        ));
+                    }
+                    n.min(MAX_REPEAT_ITERATIONS)
+                }
+                Err(_) => {
+                    summary.warnings.push(format!(
+                        "Invalid repeat count '{}' (resolved from '{}'), defaulting to 1",
+                        resolved_count_str, count_str
+                    ));
+                    1
+                }
+            };
+
+            let as_var = node.repeat_as.as_deref().unwrap_or("i");
+            let mut all_children = Vec::new();
+
+            for i in 0..count {
+                // Create iteration variables
+                let mut iter_vars = variables.clone();
+                iter_vars.insert(format!("%{}%", as_var), i.to_string());
+                iter_vars.insert(format!("%{}_1%", as_var), (i + 1).to_string());
+
+                // Use process_diff_children to properly handle if/else pairs
+                let iteration_children = process_diff_children(node, current_path, &iter_vars, overwrite, summary)?;
+                all_children.extend(iteration_children);
+            }
+
+            if all_children.is_empty() {
+                return Ok(None);
+            }
+
+            return Ok(Some(DiffNode {
+                id: generate_diff_id(),
+                node_type: DiffNodeType::Folder,
+                name: format!("repeat {} as {}", count, as_var),
+                path: current_path.to_string_lossy().to_string(),
+                action: DiffAction::Unchanged,
+                existing_content: None,
+                new_content: None,
+                diff_hunks: None,
+                url: None,
+                is_binary: false,
+                children: Some(all_children),
+            }));
+        }
+        _ => {}
+    }
+
+    // Apply variable substitution to name
+    let resolved_name = substitute_variables(&node.name, variables);
+    let node_path = current_path.join(&resolved_name);
+
+    // Check if path exists, handling potential errors gracefully
+    let exists = node_path.try_exists().unwrap_or(false);
+
+    match schema_node_type.as_str() {
+        "folder" => {
+            let children = process_diff_children(node, &node_path, variables, overwrite, summary)?;
+
+            let action = if exists {
+                summary.unchanged_folders += 1;
+                DiffAction::Unchanged
+            } else {
+                summary.creates += 1;
+                DiffAction::Create
+            };
+
+            Ok(Some(DiffNode {
+                id: generate_diff_id(),
+                node_type: DiffNodeType::Folder,
+                name: resolved_name,
+                path: node_path.to_string_lossy().to_string(),
+                action,
+                existing_content: None,
+                new_content: None,
+                diff_hunks: None,
+                url: None,
+                is_binary: false,
+                children: if children.is_empty() { None } else { Some(children) },
+            }))
+        }
+        "file" => {
+            let action = if exists {
+                if overwrite {
+                    summary.overwrites += 1;
+                    DiffAction::Overwrite
+                } else {
+                    summary.skips += 1;
+                    DiffAction::Skip
+                }
+            } else {
+                summary.creates += 1;
+                DiffAction::Create
+            };
+
+            // Get new content (using safe UTF-8 truncation)
+            let new_content = if let Some(url) = &node.url {
+                Some(format!("[Content from URL: {}]", url))
+            } else if let Some(content) = &node.content {
+                let resolved = substitute_variables(content, variables);
+                Some(truncate_utf8(&resolved, MAX_DIFF_CONTENT_SIZE))
+            } else {
+                None
+            };
+
+            // Get existing content and compute diff if overwriting
+            let (existing_content, diff_hunks, is_binary) = if action == DiffAction::Overwrite {
+                match fs::read(&node_path) {
+                    Ok(bytes) => {
+                        if is_binary_content(&bytes) {
+                            (None, None, true)
+                        } else {
+                            let existing = String::from_utf8_lossy(&bytes);
+                            let existing_str = truncate_utf8(&existing, MAX_DIFF_CONTENT_SIZE);
+
+                            let hunks = if let Some(ref new) = new_content {
+                                if !new.starts_with("[Content from URL:") {
+                                    Some(compute_diff(&existing_str, new))
+                                } else {
+                                    None
+                                }
+                            } else {
+                                None
+                            };
+
+                            (Some(existing_str), hunks, false)
+                        }
+                    }
+                    Err(_) => (None, None, false)
+                }
+            } else {
+                (None, None, false)
+            };
+
+            Ok(Some(DiffNode {
+                id: generate_diff_id(),
+                node_type: DiffNodeType::File,
+                name: resolved_name,
+                path: node_path.to_string_lossy().to_string(),
+                action,
+                existing_content,
+                new_content,
+                diff_hunks,
+                url: node.url.clone(),
+                is_binary,
+                children: None,
+            }))
+        }
+        _ => Ok(None)
+    }
+}
+
+/// Process children of a node, handling if/else conditional pairs correctly.
+///
+/// The if/else handling works as follows:
+/// 1. When we encounter an "if" node, we check its condition
+/// 2. If truthy, we process its children and set skip_next_else=true
+/// 3. If falsy, we skip its children and set skip_next_else=false
+/// 4. When we encounter an "else" node immediately after, we check skip_next_else
+/// 5. The skip flag is reset after processing an else, or when a non-else node
+///    follows something other than an if (handles malformed schemas gracefully)
+fn process_diff_children(
+    node: &SchemaNode,
+    current_path: &PathBuf,
+    variables: &HashMap<String, String>,
+    overwrite: bool,
+    summary: &mut DiffSummary,
+) -> Result<Vec<DiffNode>, String> {
+    let mut children = Vec::new();
+
+    if let Some(node_children) = &node.children {
+        let mut skip_next_else = false;
+        let mut last_was_if = false;
+
+        for child in node_children {
+            // Handle if/else pairs
+            if child.node_type == "if" {
+                let var_name = child.condition_var.as_deref().unwrap_or("CONDITION");
+                let (is_truthy, _) = check_var_truthy(var_name, variables);
+
+                skip_next_else = is_truthy;
+
+                if is_truthy {
+                    // Use process_diff_children recursively to properly handle nested if/else pairs
+                    let nested_children = process_diff_children(child, current_path, variables, overwrite, summary)?;
+                    children.extend(nested_children);
+                }
+                last_was_if = true;
+                continue;
+            }
+
+            if child.node_type == "else" {
+                if !skip_next_else {
+                    // Use process_diff_children recursively to properly handle nested if/else pairs
+                    let nested_children = process_diff_children(child, current_path, variables, overwrite, summary)?;
+                    children.extend(nested_children);
+                }
+                skip_next_else = false;
+                last_was_if = false;
+                continue;
+            }
+
+            // Reset skip flag when a non-else node follows a non-if node.
+            // This handles edge cases where the schema might have unexpected ordering.
+            if !last_was_if {
+                skip_next_else = false;
+            }
+            last_was_if = false;
+
+            if let Some(diff_node) = generate_diff_node(child, current_path, variables, overwrite, summary)? {
+                children.push(diff_node);
+            }
+        }
+    }
+
+    Ok(children)
+}
+
+/// Generate a diff preview for the schema tree
+pub fn generate_diff_preview(
+    tree: &SchemaTree,
+    output_path: &str,
+    variables: &HashMap<String, String>,
+    overwrite: bool,
+) -> Result<DiffResult, String> {
+    let base_path = PathBuf::from(output_path);
+    let mut summary = DiffSummary {
+        total_items: 0,
+        creates: 0,
+        overwrites: 0,
+        skips: 0,
+        unchanged_folders: 0,
+        warnings: Vec::new(),
+    };
+
+    let root = generate_diff_node(&tree.root, &base_path, variables, overwrite, &mut summary)?
+        .ok_or_else(|| "Failed to generate diff for root node".to_string())?;
+
+    // Compute total_items from the individual counts
+    summary.total_items = summary.creates + summary.overwrites + summary.skips + summary.unchanged_folders;
+
+    Ok(DiffResult { root, summary })
+}
+
+#[cfg(feature = "tauri-app")]
+#[tauri::command]
+fn cmd_generate_diff_preview(
+    tree: SchemaTree,
+    output_path: String,
+    variables: HashMap<String, String>,
+    overwrite: bool,
+) -> Result<DiffResult, String> {
+    generate_diff_preview(&tree, &output_path, &variables, overwrite)
+}
+
 #[cfg(feature = "tauri-app")]
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -2722,7 +3295,8 @@ pub fn run() {
             cmd_import_templates_from_url,
             cmd_get_settings,
             cmd_set_setting,
-            cmd_validate_variables
+            cmd_validate_variables,
+            cmd_generate_diff_preview
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/components/DiffPreviewModal.tsx
+++ b/src/components/DiffPreviewModal.tsx
@@ -1,0 +1,572 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import { XIcon, ChevronRightIcon, ChevronDownIcon, FolderIcon, FileIcon, LoaderIcon, AlertCircleIcon } from "./Icons";
+import type { DiffResult, DiffNode, DiffAction, DiffHunk, DiffLineType } from "../types/schema";
+
+interface DiffPreviewModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  diffResult: DiffResult | null;
+  onProceed: () => void;
+  isLoading: boolean;
+  error?: string | null;
+}
+
+// Action styling configuration for tree nodes
+const ACTION_STYLES: Record<DiffAction, { bg: string; text: string; badge: string; label: string }> = {
+  create: {
+    bg: "bg-system-green/10",
+    text: "text-system-green",
+    badge: "bg-system-green text-white",
+    label: "NEW",
+  },
+  overwrite: {
+    bg: "bg-system-red/10",
+    text: "text-system-red",
+    badge: "bg-system-red text-white",
+    label: "OVERWRITE",
+  },
+  skip: {
+    bg: "bg-system-orange/10",
+    text: "text-system-orange",
+    badge: "bg-system-orange text-white",
+    label: "SKIP",
+  },
+  unchanged: {
+    bg: "",
+    text: "text-text-muted",
+    badge: "",
+    label: "",
+  },
+};
+
+// Line styling configuration for diff hunks
+const LINE_STYLES: Record<DiffLineType, { bg: string; text: string; prefix: string }> = {
+  add: {
+    bg: "bg-system-green/10",
+    text: "text-system-green",
+    prefix: "+",
+  },
+  remove: {
+    bg: "bg-system-red/10",
+    text: "text-system-red",
+    prefix: "-",
+  },
+  context: {
+    bg: "",
+    text: "text-text-secondary",
+    prefix: " ",
+  },
+  truncated: {
+    bg: "bg-system-orange/10",
+    text: "text-system-orange italic",
+    prefix: "…",
+  },
+};
+
+interface DiffTreeItemProps {
+  node: DiffNode;
+  depth: number;
+  expandedNodes: Set<string>;
+  selectedId: string | null;
+  onToggle: (id: string) => void;
+  onSelect: (node: DiffNode) => void;
+}
+
+const DiffTreeItem = ({
+  node,
+  depth,
+  expandedNodes,
+  selectedId,
+  onToggle,
+  onSelect,
+}: DiffTreeItemProps) => {
+  const isExpanded = expandedNodes.has(node.id);
+  const isSelected = selectedId === node.id;
+  const hasChildren = node.children && node.children.length > 0;
+  const style = ACTION_STYLES[node.action];
+  const isFolder = node.node_type === "folder";
+
+  // Shared activation handler for click and keyboard
+  const handleActivate = useCallback(() => {
+    if (node.children && node.children.length > 0) {
+      onToggle(node.id);
+    }
+    if (node.node_type === "file") {
+      onSelect(node);
+    }
+  }, [node, onToggle, onSelect]);
+
+  return (
+    <div
+      role="treeitem"
+      aria-expanded={hasChildren ? isExpanded : undefined}
+      aria-selected={isSelected}
+      aria-label={`${node.name}${style.label ? `, ${style.label}` : ""}`}
+    >
+      <div
+        className={`flex items-center gap-1.5 py-1 px-2 cursor-pointer rounded-mac transition-colors ${
+          isSelected ? "bg-accent/20" : style.bg || "hover:bg-mac-bg-hover"
+        }`}
+        style={{ paddingLeft: `${depth * 16 + 8}px` }}
+        onClick={handleActivate}
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            handleActivate();
+          }
+        }}
+      >
+        {/* Expand/collapse chevron */}
+        {hasChildren ? (
+          <button
+            className="w-4 h-4 flex items-center justify-center text-text-muted hover:text-text-primary"
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggle(node.id);
+            }}
+            tabIndex={-1}
+            aria-hidden="true"
+          >
+            {isExpanded ? (
+              <ChevronDownIcon size={12} />
+            ) : (
+              <ChevronRightIcon size={12} />
+            )}
+          </button>
+        ) : (
+          <span className="w-4" aria-hidden="true" />
+        )}
+
+        {/* Icon */}
+        {isFolder ? (
+          <FolderIcon size={14} className={style.text || "text-system-blue"} aria-hidden="true" />
+        ) : (
+          <FileIcon size={14} className={style.text || "text-text-muted"} aria-hidden="true" />
+        )}
+
+        {/* Name */}
+        <span className={`text-mac-sm truncate flex-1 ${style.text}`}>
+          {node.name}
+        </span>
+
+        {/* Action badge */}
+        {style.label && (
+          <span className={`text-[10px] font-medium px-1.5 py-0.5 rounded ${style.badge}`} aria-hidden="true">
+            {style.label}
+          </span>
+        )}
+      </div>
+
+      {/* Children */}
+      {isExpanded && hasChildren && (
+        <div role="group">
+          {node.children!.map((child) => (
+            <DiffTreeItem
+              key={child.id}
+              node={child}
+              depth={depth + 1}
+              expandedNodes={expandedNodes}
+              selectedId={selectedId}
+              onToggle={onToggle}
+              onSelect={onSelect}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+interface DiffContentViewerProps {
+  node: DiffNode | null;
+}
+
+const DiffContentViewer = ({ node }: DiffContentViewerProps) => {
+  if (!node) {
+    return (
+      <div className="flex items-center justify-center h-full text-text-muted text-mac-sm">
+        Select a file to view details
+      </div>
+    );
+  }
+
+  if (node.is_binary) {
+    return (
+      <div className="p-4">
+        <div className="text-text-muted text-mac-sm">
+          Binary file - diff not available
+        </div>
+      </div>
+    );
+  }
+
+  if (node.url) {
+    return (
+      <div className="p-4">
+        <div className="text-mac-sm mb-2 font-medium text-text-primary">
+          Content from URL:
+        </div>
+        <div className="font-mono text-mac-xs text-system-blue break-all">
+          {node.url}
+        </div>
+      </div>
+    );
+  }
+
+  // Show diff hunks for overwrites
+  if (node.action === "overwrite" && node.diff_hunks && node.diff_hunks.length > 0) {
+    return (
+      <div className="p-2 overflow-auto">
+        <div className="font-mono text-mac-xs">
+          {node.diff_hunks.map((hunk) => (
+            <DiffHunkView key={`${hunk.old_start}-${hunk.new_start}`} hunk={hunk} />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  // Show new content for creates
+  if (node.action === "create" && node.new_content) {
+    return (
+      <div className="p-2 overflow-auto">
+        <div className="text-mac-xs text-text-muted mb-2">New file content:</div>
+        <pre className="font-mono text-mac-xs text-system-green whitespace-pre-wrap break-all bg-system-green/5 p-2 rounded-mac">
+          {node.new_content}
+        </pre>
+      </div>
+    );
+  }
+
+  // Show skip info
+  if (node.action === "skip") {
+    return (
+      <div className="p-4">
+        <div className="text-text-muted text-mac-sm">
+          File exists and will be skipped (overwrite is disabled)
+        </div>
+      </div>
+    );
+  }
+
+  // Show empty file creation message
+  if (node.action === "create" && !node.new_content) {
+    return (
+      <div className="p-4">
+        <div className="text-text-muted text-mac-sm">
+          Empty file will be created
+        </div>
+      </div>
+    );
+  }
+
+  // Show overwrite without diff (identical content or diff unavailable)
+  if (node.action === "overwrite") {
+    return (
+      <div className="p-4">
+        <div className="text-text-muted text-mac-sm">
+          File will be overwritten (content identical or diff unavailable)
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4">
+      <div className="text-text-muted text-mac-sm">
+        No content changes to display
+      </div>
+    </div>
+  );
+};
+
+const DiffHunkView = ({ hunk }: { hunk: DiffHunk }) => {
+  return (
+    <div className="mb-4">
+      <div className="text-text-muted text-[10px] mb-1 font-medium">
+        @@ -{hunk.old_start},{hunk.old_count} +{hunk.new_start},{hunk.new_count} @@
+      </div>
+      <div className="border border-border-muted rounded-mac overflow-hidden">
+        {hunk.lines.map((line, lineIndex) => {
+          const style = LINE_STYLES[line.line_type];
+          return (
+            <div
+              key={`${line.line_type}-${lineIndex}`}
+              className={`${style.bg} ${style.text} px-2 py-0.5 whitespace-pre-wrap break-all`}
+            >
+              <span className="select-none opacity-50 mr-2">{style.prefix}</span>
+              {line.content.replace(/\n$/, "")}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export const DiffPreviewModal = ({
+  isOpen,
+  onClose,
+  diffResult,
+  onProceed,
+  isLoading,
+  error,
+}: DiffPreviewModalProps) => {
+  const [expandedNodes, setExpandedNodes] = useState<Set<string>>(new Set());
+  const [selectedNode, setSelectedNode] = useState<DiffNode | null>(null);
+  const modalRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  // Reset state when modal opens
+  useEffect(() => {
+    if (isOpen && diffResult) {
+      // Auto-expand root and first level
+      const initialExpanded = new Set<string>();
+      initialExpanded.add(diffResult.root.id);
+      diffResult.root.children?.forEach((child) => {
+        if (child.node_type === "folder") {
+          initialExpanded.add(child.id);
+        }
+      });
+      setExpandedNodes(initialExpanded);
+      setSelectedNode(null);
+    }
+  }, [isOpen, diffResult]);
+
+  // Focus trap and escape key handling
+  useEffect(() => {
+    if (!isOpen) return;
+
+    // Focus the close button when modal opens
+    closeButtonRef.current?.focus();
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+      }
+
+      // Simple focus trap - Tab cycles within modal
+      if (e.key === "Tab" && modalRef.current) {
+        const focusableElements = modalRef.current.querySelectorAll(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+
+        // Guard against empty focusable elements
+        if (focusableElements.length === 0) return;
+
+        const firstElement = focusableElements[0] as HTMLElement;
+        const lastElement = focusableElements[focusableElements.length - 1] as HTMLElement;
+
+        if (e.shiftKey && document.activeElement === firstElement) {
+          e.preventDefault();
+          lastElement?.focus();
+        } else if (!e.shiftKey && document.activeElement === lastElement) {
+          e.preventDefault();
+          firstElement?.focus();
+        }
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onClose]);
+
+  const handleToggle = useCallback((id: string) => {
+    setExpandedNodes((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleSelect = useCallback((node: DiffNode) => {
+    setSelectedNode(node);
+  }, []);
+
+  if (!isOpen) return null;
+
+  const summary = diffResult?.summary;
+  const hasChanges = summary ? (summary.creates > 0 || summary.overwrites > 0) : false;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="diff-preview-title"
+    >
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Modal */}
+      <div
+        ref={modalRef}
+        className="relative bg-card-bg rounded-mac-lg shadow-mac-xl w-full max-w-[800px] mx-4 max-h-[85vh] overflow-hidden border border-border-muted flex flex-col"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-border-muted shrink-0">
+          <h2 id="diff-preview-title" className="text-mac-lg font-semibold text-text-primary">
+            Diff Preview
+          </h2>
+          <button
+            ref={closeButtonRef}
+            onClick={onClose}
+            className="w-7 h-7 flex items-center justify-center rounded-mac text-text-muted hover:bg-mac-bg-hover transition-colors"
+            aria-label="Close dialog"
+          >
+            <XIcon size={16} />
+          </button>
+        </div>
+
+        {/* Loading state */}
+        {isLoading && (
+          <div className="flex-1 flex items-center justify-center p-8" role="status" aria-live="polite">
+            <LoaderIcon size={32} className="text-accent animate-spin" />
+            <span className="ml-3 text-text-secondary">Analyzing changes...</span>
+          </div>
+        )}
+
+        {/* Error state */}
+        {!isLoading && error && (
+          <div className="flex-1 flex flex-col items-center justify-center p-8 text-center">
+            <AlertCircleIcon size={48} className="text-system-red mb-4" />
+            <h3 className="text-mac-base font-medium text-text-primary mb-2">
+              Failed to generate diff preview
+            </h3>
+            <p className="text-mac-sm text-text-muted max-w-md mb-4">
+              {error}
+            </p>
+            <button
+              onClick={onClose}
+              className="mac-button-secondary px-4 py-2"
+            >
+              Close
+            </button>
+          </div>
+        )}
+
+        {/* Content */}
+        {!isLoading && !error && diffResult && (
+          <>
+            {/* Summary bar */}
+            <div className="px-5 py-3 border-b border-border-muted bg-mac-bg-secondary shrink-0">
+              <div className="flex items-center gap-4 text-mac-sm">
+                {/* Show total count */}
+                {summary && (
+                  <span className="text-text-muted">
+                    {summary.total_items} item{summary.total_items !== 1 ? "s" : ""}:
+                  </span>
+                )}
+                {summary && summary.creates > 0 && (
+                  <span className="flex items-center gap-1.5">
+                    <span className="w-2 h-2 rounded-full bg-system-green" aria-hidden="true" />
+                    <span className="text-text-secondary">
+                      {summary.creates} new {summary.creates === 1 ? "file" : "files"}
+                    </span>
+                  </span>
+                )}
+                {summary && summary.overwrites > 0 && (
+                  <span className="flex items-center gap-1.5">
+                    <span className="w-2 h-2 rounded-full bg-system-red" aria-hidden="true" />
+                    <span className="text-text-secondary">
+                      {summary.overwrites} to overwrite
+                    </span>
+                  </span>
+                )}
+                {summary && summary.skips > 0 && (
+                  <span className="flex items-center gap-1.5">
+                    <span className="w-2 h-2 rounded-full bg-system-orange" aria-hidden="true" />
+                    <span className="text-text-secondary">
+                      {summary.skips} skipped
+                    </span>
+                  </span>
+                )}
+                {summary && summary.unchanged_folders > 0 && (
+                  <span className="flex items-center gap-1.5">
+                    <span className="w-2 h-2 rounded-full bg-text-muted" aria-hidden="true" />
+                    <span className="text-text-muted">
+                      {summary.unchanged_folders} existing {summary.unchanged_folders === 1 ? "folder" : "folders"}
+                    </span>
+                  </span>
+                )}
+                {/* Show message when no actionable changes */}
+                {summary && summary.creates === 0 && summary.overwrites === 0 && summary.skips === 0 && (
+                  <span className="text-text-muted italic">No changes to make</span>
+                )}
+              </div>
+              {/* Warnings */}
+              {summary && summary.warnings && summary.warnings.length > 0 && (
+                <div className="mt-2 text-mac-xs text-system-orange">
+                  {summary.warnings.map((warning, idx) => (
+                    <div key={`warning-${idx}`} className="flex items-start gap-1.5">
+                      <AlertCircleIcon size={12} className="flex-shrink-0 mt-0.5" aria-hidden="true" />
+                      <span>{warning}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Split pane */}
+            <div className="flex-1 flex min-h-0">
+              {/* Tree panel */}
+              <div
+                className="w-[320px] min-w-[200px] shrink-0 border-r border-border-muted overflow-y-auto mac-scroll"
+                role="tree"
+                aria-label="File changes tree"
+              >
+                <div className="py-2">
+                  <DiffTreeItem
+                    node={diffResult.root}
+                    depth={0}
+                    expandedNodes={expandedNodes}
+                    selectedId={selectedNode?.id ?? null}
+                    onToggle={handleToggle}
+                    onSelect={handleSelect}
+                  />
+                </div>
+              </div>
+
+              {/* Content panel */}
+              <div
+                className="flex-1 overflow-y-auto mac-scroll bg-mac-bg"
+                role="region"
+                aria-label="File content preview"
+              >
+                <DiffContentViewer node={selectedNode} />
+              </div>
+            </div>
+          </>
+        )}
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-3 px-5 py-4 border-t border-border-muted shrink-0">
+          <button
+            onClick={onClose}
+            className="mac-button-secondary px-4 py-2"
+            disabled={isLoading}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onProceed}
+            className="mac-button-primary px-4 py-2"
+            disabled={isLoading || !diffResult || !hasChanges}
+            title={!hasChanges ? "No changes to apply" : undefined}
+          >
+            Proceed
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -460,3 +460,61 @@ export const RepeatIcon = ({ className, size = 24 }: IconProps) => (
     <path d="M21 13v2a4 4 0 0 1-4 4H3" />
   </svg>
 );
+
+export const ChevronRightIcon = ({ className, size = 24 }: IconProps) => (
+  <svg
+    className={className}
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <polyline points="9 18 15 12 9 6" />
+  </svg>
+);
+
+export const ChevronDownIcon = ({ className, size = 24 }: IconProps) => (
+  <svg
+    className={className}
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <polyline points="6 9 12 15 18 9" />
+  </svg>
+);
+
+export const LoaderIcon = ({ className, size = 24 }: IconProps) => (
+  <svg
+    className={className}
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <line x1="12" y1="2" x2="12" y2="6" />
+    <line x1="12" y1="18" x2="12" y2="22" />
+    <line x1="4.93" y1="4.93" x2="7.76" y2="7.76" />
+    <line x1="16.24" y1="16.24" x2="19.07" y2="19.07" />
+    <line x1="2" y1="12" x2="6" y2="12" />
+    <line x1="18" y1="12" x2="22" y2="12" />
+    <line x1="4.93" y1="19.07" x2="7.76" y2="16.24" />
+    <line x1="16.24" y1="7.76" x2="19.07" y2="4.93" />
+  </svg>
+);

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import type { AppState, CreationProgress, LogEntry, Variable, SchemaTree, SchemaNode, Template, Settings, ValidationRule, ValidationError } from "../types/schema";
+import type { AppState, CreationProgress, LogEntry, Variable, SchemaTree, SchemaNode, Template, Settings, ValidationRule, ValidationError, DiffResult } from "../types/schema";
 import { DEFAULT_SETTINGS } from "../types/schema";
 import { findNode, canHaveChildren, isDescendant, removeNodesById, getIfElseGroup, moveIfElseGroupToParent } from "../utils/schemaTree";
 
@@ -179,6 +179,12 @@ export const useAppStore = create<AppState>((set, get) => ({
   dryRun: false,
   overwrite: false,
 
+  // Diff Preview
+  diffResult: null,
+  diffLoading: false,
+  diffError: null,
+  showDiffModal: false,
+
   // Actions
   setSchemaPath: (path: string | null) => set({ schemaPath: path }),
 
@@ -308,6 +314,12 @@ export const useAppStore = create<AppState>((set, get) => ({
 
   setOverwrite: (overwrite: boolean) => set({ overwrite }),
 
+  // Diff Preview actions
+  setDiffResult: (diffResult: DiffResult | null) => set({ diffResult }),
+  setDiffLoading: (diffLoading: boolean) => set({ diffLoading }),
+  setDiffError: (diffError: string | null) => set({ diffError }),
+  setShowDiffModal: (showDiffModal: boolean) => set({ showDiffModal }),
+
   reset: () =>
     set({
       schemaPath: null,
@@ -318,6 +330,10 @@ export const useAppStore = create<AppState>((set, get) => ({
       schemaDirty: false,
       schemaHistory: [],
       schemaHistoryIndex: -1,
+      diffResult: null,
+      diffLoading: false,
+      diffError: null,
+      showDiffModal: false,
     }),
 
   // Schema editing actions

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -229,6 +229,84 @@ export interface CreateResult {
   hook_results: HookResult[];
 }
 
+// ============================================================================
+// Diff Preview Types
+// ============================================================================
+
+/** Action that would be taken for a filesystem entry */
+export type DiffAction = "create" | "overwrite" | "skip" | "unchanged";
+
+/** Type of node in the diff tree */
+export type DiffNodeType = "folder" | "file";
+
+/** Type of diff line */
+export type DiffLineType = "add" | "remove" | "context" | "truncated";
+
+/** A single line in a diff hunk */
+export interface DiffLine {
+  /** Type of this diff line */
+  line_type: DiffLineType;
+  /** The line content */
+  content: string;
+}
+
+/** A diff hunk representing a contiguous block of changes */
+export interface DiffHunk {
+  /** Line number in old file (1-indexed) */
+  old_start: number;
+  /** Number of lines from old file in this hunk */
+  old_count: number;
+  /** Line number in new file (1-indexed) */
+  new_start: number;
+  /** Number of lines from new file in this hunk */
+  new_count: number;
+  /** The diff lines */
+  lines: DiffLine[];
+}
+
+/** Represents a file or folder in the diff preview tree */
+export interface DiffNode {
+  /** Unique identifier for frontend tree navigation */
+  id: string;
+  /** Type of this node (folder or file) */
+  node_type: DiffNodeType;
+  /** Display name (with variables substituted) */
+  name: string;
+  /** Full path relative to output directory */
+  path: string;
+  /** Action to be taken */
+  action: DiffAction;
+  /** For files: existing content (if overwriting) */
+  existing_content?: string;
+  /** For files: new content to be written */
+  new_content?: string;
+  /** For files: computed diff hunks (for text files only) */
+  diff_hunks?: DiffHunk[];
+  /** For files with URLs: the source URL */
+  url?: string;
+  /** Whether this is a binary file (no text diff available) */
+  is_binary: boolean;
+  /** Child nodes (for folders) */
+  children?: DiffNode[];
+}
+
+/** Summary statistics for the diff preview */
+export interface DiffSummary {
+  total_items: number;
+  creates: number;
+  overwrites: number;
+  skips: number;
+  unchanged_folders: number;
+  /** Warnings generated during diff preview (e.g., invalid repeat counts) */
+  warnings?: string[];
+}
+
+/** Complete diff preview result */
+export interface DiffResult {
+  root: DiffNode;
+  summary: DiffSummary;
+}
+
 export interface CreationProgress {
   current: number;
   total: number;
@@ -271,6 +349,12 @@ export interface AppState {
   dryRun: boolean;
   overwrite: boolean;
 
+  // Diff Preview
+  diffResult: DiffResult | null;
+  diffLoading: boolean;
+  diffError: string | null;
+  showDiffModal: boolean;
+
   // Actions
   setSchemaPath: (path: string | null) => void;
   setSchemaContent: (content: string | null) => void;
@@ -296,6 +380,10 @@ export interface AppState {
   clearLogs: () => void;
   setDryRun: (dryRun: boolean) => void;
   setOverwrite: (overwrite: boolean) => void;
+  setDiffResult: (result: DiffResult | null) => void;
+  setDiffLoading: (loading: boolean) => void;
+  setDiffError: (error: string | null) => void;
+  setShowDiffModal: (show: boolean) => void;
   reset: () => void;
 
   // Schema editing actions


### PR DESCRIPTION
Adds a visual diff preview modal when Dry Run is enabled, showing:
- Color-coded tree view of changes (create/overwrite/skip)
- Inline text diffs for files that would be overwritten
- Summary statistics with warnings for invalid configurations
- Disabled Proceed button when no actionable changes

Closes #9 