### PR TITLE
Add template search, tags, filtering, and sorting (Issue #10)

### DIFF
--- a/src-tauri/src/bin/cli.rs
+++ b/src-tauri/src/bin/cli.rs
@@ -222,6 +222,8 @@ struct TemplateExport {
     icon_color: Option<String>,
     #[serde(default)]
     is_favorite: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    tags: Vec<String>,
 }
 
 /// CLI execution result
@@ -849,6 +851,7 @@ fn cmd_templates_export(name: &str, output: &std::path::Path, overwrite: bool, q
         variable_validation: template.variable_validation,
         icon_color: template.icon_color,
         is_favorite: template.is_favorite,
+        tags: template.tags,
     };
 
     let content = match serde_json::to_string_pretty(&export) {
@@ -968,6 +971,7 @@ fn cmd_templates_import(path: &std::path::Path, force: bool, quiet: bool) -> Cli
         variable_validation: export.variable_validation,
         icon_color: export.icon_color,
         is_favorite: export.is_favorite,
+        tags: export.tags,
     };
 
     let template = match db.create_template(input) {

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -14,6 +14,52 @@ pub struct ValidationRule {
     pub required: bool,
 }
 
+/// Maximum length for a single tag (in characters, not bytes).
+/// NOTE: This constant is duplicated in src/components/TagInput.tsx for client-side validation.
+/// If you change this value, update the TypeScript constant to match.
+const MAX_TAG_LENGTH: usize = 50;
+/// Maximum number of tags per template.
+/// NOTE: This constant is duplicated in src/components/TagInput.tsx for client-side validation.
+/// If you change this value, update the TypeScript constant to match.
+const MAX_TAGS_COUNT: usize = 20;
+
+/// Sanitize and normalize tags:
+/// - Convert to lowercase
+/// - Trim whitespace
+/// - Strip non-printable/control characters
+/// - Enforce length limit per tag
+/// - Enforce total count limit
+/// - Remove duplicates
+/// - Remove empty tags
+fn sanitize_tags(tags: Vec<String>) -> Vec<String> {
+    let mut seen = std::collections::HashSet::new();
+    tags.into_iter()
+        .map(|tag| {
+            // Trim and lowercase
+            let normalized = tag.trim().to_lowercase();
+            // Strip non-printable characters (keep only printable ASCII and common unicode)
+            normalized
+                .chars()
+                .filter(|c| !c.is_control() && *c != '\u{0}')
+                .collect::<String>()
+        })
+        // Remove empty tags
+        .filter(|tag| !tag.is_empty())
+        // Enforce per-tag length limit (using char count for multi-byte UTF-8 safety)
+        .map(|tag| {
+            if tag.chars().count() > MAX_TAG_LENGTH {
+                tag.chars().take(MAX_TAG_LENGTH).collect()
+            } else {
+                tag
+            }
+        })
+        // Remove duplicates while preserving order
+        .filter(|tag| seen.insert(tag.clone()))
+        // Enforce total count limit
+        .take(MAX_TAGS_COUNT)
+        .collect()
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Template {
     pub id: String,
@@ -28,10 +74,12 @@ pub struct Template {
     pub use_count: i32,
     pub created_at: String,
     pub updated_at: String,
+    #[serde(default)]
+    pub tags: Vec<String>,
 }
 
 /// Helper function to construct a Template from a database row.
-/// Expects columns in order: id, name, description, schema_xml, variables, variable_validation, icon_color, is_favorite, use_count, created_at, updated_at
+/// Expects columns in order: id, name, description, schema_xml, variables, variable_validation, icon_color, is_favorite, use_count, created_at, updated_at, tags
 fn row_to_template(row: &Row) -> rusqlite::Result<Template> {
     let variables_json: String = row.get(4)?;
     let variables: HashMap<String, String> = serde_json::from_str(&variables_json)
@@ -53,6 +101,17 @@ fn row_to_template(row: &Row) -> rusqlite::Result<Template> {
         })
         .unwrap_or_default();
 
+    // tags may be NULL for older templates
+    let tags_json: Option<String> = row.get(11)?;
+    let tags: Vec<String> = tags_json
+        .map(|json| {
+            serde_json::from_str(&json).unwrap_or_else(|e| {
+                eprintln!("Warning: Failed to parse tags JSON, using empty: {}", e);
+                Vec::new()
+            })
+        })
+        .unwrap_or_default();
+
     Ok(Template {
         id: row.get(0)?,
         name: row.get(1)?,
@@ -65,6 +124,7 @@ fn row_to_template(row: &Row) -> rusqlite::Result<Template> {
         use_count: row.get(8)?,
         created_at: row.get(9)?,
         updated_at: row.get(10)?,
+        tags,
     })
 }
 
@@ -79,6 +139,8 @@ pub struct CreateTemplateInput {
     pub icon_color: Option<String>,
     #[serde(default)]
     pub is_favorite: bool,
+    #[serde(default)]
+    pub tags: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -159,6 +221,17 @@ impl Database {
             }
         }
 
+        // Migration: Add tags column if it doesn't exist (for existing databases)
+        if let Err(e) = conn.execute(
+            "ALTER TABLE templates ADD COLUMN tags TEXT DEFAULT '[]'",
+            [],
+        ) {
+            let err_msg = e.to_string();
+            if !err_msg.contains("duplicate column") {
+                eprintln!("Warning: Migration failed (tags column): {}", err_msg);
+            }
+        }
+
         conn.execute(
             "CREATE TABLE IF NOT EXISTS settings (
                 key TEXT PRIMARY KEY,
@@ -174,7 +247,7 @@ impl Database {
         let conn = self.conn.lock().unwrap();
 
         let mut stmt = conn.prepare(
-            "SELECT id, name, description, schema_xml, variables, variable_validation, icon_color, is_favorite, use_count, created_at, updated_at
+            "SELECT id, name, description, schema_xml, variables, variable_validation, icon_color, is_favorite, use_count, created_at, updated_at, tags
              FROM templates
              ORDER BY is_favorite DESC, use_count DESC, updated_at DESC",
         )?;
@@ -187,7 +260,7 @@ impl Database {
         let conn = self.conn.lock().unwrap();
 
         let mut stmt = conn.prepare(
-            "SELECT id, name, description, schema_xml, variables, variable_validation, icon_color, is_favorite, use_count, created_at, updated_at
+            "SELECT id, name, description, schema_xml, variables, variable_validation, icon_color, is_favorite, use_count, created_at, updated_at, tags
              FROM templates
              WHERE id = ?",
         )?;
@@ -204,7 +277,7 @@ impl Database {
         let conn = self.conn.lock().unwrap();
 
         let mut stmt = conn.prepare(
-            "SELECT id, name, description, schema_xml, variables, variable_validation, icon_color, is_favorite, use_count, created_at, updated_at
+            "SELECT id, name, description, schema_xml, variables, variable_validation, icon_color, is_favorite, use_count, created_at, updated_at, tags
              FROM templates
              WHERE LOWER(name) = LOWER(?)",
         )?;
@@ -223,11 +296,14 @@ impl Database {
         let now = chrono::Utc::now().to_rfc3339();
         let variables_json = serde_json::to_string(&input.variables).unwrap_or_else(|_| "{}".to_string());
         let validation_json = serde_json::to_string(&input.variable_validation).unwrap_or_else(|_| "{}".to_string());
+        // Sanitize tags before storing
+        let sanitized_tags = sanitize_tags(input.tags);
+        let tags_json = serde_json::to_string(&sanitized_tags).unwrap_or_else(|_| "[]".to_string());
         let is_favorite_int = if input.is_favorite { 1 } else { 0 };
 
         conn.execute(
-            "INSERT INTO templates (id, name, description, schema_xml, variables, variable_validation, icon_color, is_favorite, use_count, created_at, updated_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)",
+            "INSERT INTO templates (id, name, description, schema_xml, variables, variable_validation, icon_color, is_favorite, use_count, created_at, updated_at, tags)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?)",
             rusqlite::params![
                 &id,
                 &input.name,
@@ -239,6 +315,7 @@ impl Database {
                 is_favorite_int,
                 &now,
                 &now,
+                &tags_json,
             ],
         )?;
 
@@ -254,6 +331,7 @@ impl Database {
             use_count: 0,
             created_at: now.clone(),
             updated_at: now,
+            tags: sanitized_tags,
         })
     }
 
@@ -420,6 +498,34 @@ impl Database {
         }
         Ok(template)
     }
+
+    /// Update tags for a template
+    pub fn update_template_tags(&self, id: &str, tags: Vec<String>) -> SqliteResult<Option<Template>> {
+        let conn = self.conn.lock().unwrap();
+        // Sanitize tags before storing
+        let sanitized_tags = sanitize_tags(tags);
+        let tags_json = serde_json::to_string(&sanitized_tags).unwrap_or_else(|_| "[]".to_string());
+        let now = chrono::Utc::now().to_rfc3339();
+
+        conn.execute(
+            "UPDATE templates SET tags = ?, updated_at = ? WHERE id = ?",
+            [&tags_json, &now, id],
+        )?;
+
+        drop(conn);
+        self.get_template(id)
+    }
+
+    /// Get all unique tags from all templates
+    pub fn get_all_tags(&self) -> SqliteResult<Vec<String>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT DISTINCT value FROM templates, json_each(templates.tags)
+             WHERE tags IS NOT NULL AND tags != '[]' ORDER BY value"
+        )?;
+        let tags = stmt.query_map([], |row| row.get(0))?;
+        tags.collect()
+    }
 }
 
 #[cfg(test)]
@@ -443,6 +549,20 @@ mod tests {
             variable_validation: HashMap::new(),
             icon_color: Some("#ff0000".to_string()),
             is_favorite: false,
+            tags: Vec::new(),
+        }
+    }
+
+    fn create_test_template_with_tags(name: &str, tags: Vec<&str>) -> CreateTemplateInput {
+        CreateTemplateInput {
+            name: name.to_string(),
+            description: Some("Test description".to_string()),
+            schema_xml: "<folder name=\"test\"/>".to_string(),
+            variables: HashMap::new(),
+            variable_validation: HashMap::new(),
+            icon_color: Some("#ff0000".to_string()),
+            is_favorite: false,
+            tags: tags.into_iter().map(String::from).collect(),
         }
     }
 
@@ -574,6 +694,280 @@ mod tests {
 
             assert!(db.get_template_by_name("camelcase").unwrap().is_some());
             assert!(db.get_template_by_name("CAMELCASE").unwrap().is_some());
+        }
+    }
+
+    mod template_tags_tests {
+        use super::*;
+
+        #[test]
+        fn creates_template_with_tags() {
+            let (db, _dir) = create_test_db();
+            let template = db.create_template(create_test_template_with_tags(
+                "Tagged Template",
+                vec!["react", "typescript"],
+            )).unwrap();
+
+            assert_eq!(template.tags, vec!["react", "typescript"]);
+        }
+
+        #[test]
+        fn creates_template_with_empty_tags() {
+            let (db, _dir) = create_test_db();
+            let template = db.create_template(create_test_template_input("No Tags")).unwrap();
+
+            assert!(template.tags.is_empty());
+        }
+
+        #[test]
+        fn retrieves_template_with_tags() {
+            let (db, _dir) = create_test_db();
+            let created = db.create_template(create_test_template_with_tags(
+                "Tagged",
+                vec!["python", "backend"],
+            )).unwrap();
+
+            let retrieved = db.get_template(&created.id).unwrap().unwrap();
+            assert_eq!(retrieved.tags, vec!["python", "backend"]);
+        }
+    }
+
+    mod update_template_tags_tests {
+        use super::*;
+
+        #[test]
+        fn updates_tags_successfully() {
+            let (db, _dir) = create_test_db();
+            let template = db.create_template(create_test_template_input("Update Me")).unwrap();
+
+            let updated = db.update_template_tags(&template.id, vec!["new".to_string(), "tags".to_string()]).unwrap().unwrap();
+
+            assert_eq!(updated.tags, vec!["new", "tags"]);
+        }
+
+        #[test]
+        fn clears_tags_with_empty_vector() {
+            let (db, _dir) = create_test_db();
+            let template = db.create_template(create_test_template_with_tags(
+                "Has Tags",
+                vec!["will", "be", "removed"],
+            )).unwrap();
+
+            let updated = db.update_template_tags(&template.id, vec![]).unwrap().unwrap();
+
+            assert!(updated.tags.is_empty());
+        }
+
+        #[test]
+        fn returns_none_for_nonexistent_template() {
+            let (db, _dir) = create_test_db();
+            let result = db.update_template_tags("nonexistent-id", vec!["tag".to_string()]).unwrap();
+
+            assert!(result.is_none());
+        }
+
+        #[test]
+        fn updates_updated_at_timestamp() {
+            let (db, _dir) = create_test_db();
+            let template = db.create_template(create_test_template_input("Timestamp Test")).unwrap();
+            let original_updated_at = template.updated_at.clone();
+
+            // Delay to ensure timestamp differs (longer for CI reliability)
+            std::thread::sleep(std::time::Duration::from_millis(50));
+
+            let updated = db.update_template_tags(&template.id, vec!["new".to_string()]).unwrap().unwrap();
+
+            assert_ne!(updated.updated_at, original_updated_at);
+        }
+    }
+
+    mod get_all_tags_tests {
+        use super::*;
+
+        #[test]
+        fn returns_empty_when_no_templates() {
+            let (db, _dir) = create_test_db();
+            let tags = db.get_all_tags().unwrap();
+
+            assert!(tags.is_empty());
+        }
+
+        #[test]
+        fn returns_empty_when_templates_have_no_tags() {
+            let (db, _dir) = create_test_db();
+            db.create_template(create_test_template_input("No Tags 1")).unwrap();
+            db.create_template(create_test_template_input("No Tags 2")).unwrap();
+
+            let tags = db.get_all_tags().unwrap();
+
+            assert!(tags.is_empty());
+        }
+
+        #[test]
+        fn returns_unique_tags_from_all_templates() {
+            let (db, _dir) = create_test_db();
+            db.create_template(create_test_template_with_tags("T1", vec!["react", "frontend"])).unwrap();
+            db.create_template(create_test_template_with_tags("T2", vec!["react", "backend"])).unwrap();
+            db.create_template(create_test_template_with_tags("T3", vec!["python"])).unwrap();
+
+            let tags = db.get_all_tags().unwrap();
+
+            assert_eq!(tags.len(), 4);
+            assert!(tags.contains(&"react".to_string()));
+            assert!(tags.contains(&"frontend".to_string()));
+            assert!(tags.contains(&"backend".to_string()));
+            assert!(tags.contains(&"python".to_string()));
+        }
+
+        #[test]
+        fn returns_tags_sorted_alphabetically() {
+            let (db, _dir) = create_test_db();
+            db.create_template(create_test_template_with_tags("T1", vec!["zebra", "apple", "mango"])).unwrap();
+
+            let tags = db.get_all_tags().unwrap();
+
+            assert_eq!(tags, vec!["apple", "mango", "zebra"]);
+        }
+
+        #[test]
+        fn excludes_templates_with_empty_tags() {
+            let (db, _dir) = create_test_db();
+            db.create_template(create_test_template_input("No Tags")).unwrap();
+            db.create_template(create_test_template_with_tags("Has Tags", vec!["only-this"])).unwrap();
+
+            let tags = db.get_all_tags().unwrap();
+
+            assert_eq!(tags, vec!["only-this"]);
+        }
+    }
+
+    mod sanitize_tags_tests {
+        use super::*;
+
+        #[test]
+        fn normalizes_to_lowercase() {
+            let result = sanitize_tags(vec!["React".to_string(), "TypeScript".to_string()]);
+            assert_eq!(result, vec!["react", "typescript"]);
+        }
+
+        #[test]
+        fn trims_whitespace() {
+            let result = sanitize_tags(vec!["  react  ".to_string(), " frontend ".to_string()]);
+            assert_eq!(result, vec!["react", "frontend"]);
+        }
+
+        #[test]
+        fn removes_empty_tags() {
+            let result = sanitize_tags(vec!["react".to_string(), "".to_string(), "   ".to_string()]);
+            assert_eq!(result, vec!["react"]);
+        }
+
+        #[test]
+        fn removes_duplicates() {
+            let result = sanitize_tags(vec!["react".to_string(), "React".to_string(), "REACT".to_string()]);
+            assert_eq!(result, vec!["react"]);
+        }
+
+        #[test]
+        fn enforces_max_tag_length() {
+            let long_tag = "a".repeat(100);
+            let result = sanitize_tags(vec![long_tag]);
+            assert_eq!(result[0].chars().count(), MAX_TAG_LENGTH);
+        }
+
+        #[test]
+        fn truncates_multibyte_characters_correctly() {
+            // Each emoji is 1 character but 4 bytes
+            // 60 emojis = 60 chars but 240 bytes
+            let emoji_tag = "🎉".repeat(60);
+            assert_eq!(emoji_tag.chars().count(), 60);
+            assert!(emoji_tag.len() > MAX_TAG_LENGTH); // bytes > 50
+
+            let result = sanitize_tags(vec![emoji_tag]);
+
+            // Should truncate to 50 characters, not 50 bytes
+            assert_eq!(result[0].chars().count(), MAX_TAG_LENGTH);
+            // Result should be valid UTF-8 (50 emojis)
+            assert_eq!(result[0], "🎉".repeat(50));
+        }
+
+        #[test]
+        fn handles_mixed_ascii_and_multibyte() {
+            // Mix of ASCII and multi-byte: "hello" (5) + 50 emojis (50) = 55 chars
+            let mixed_tag = format!("hello{}", "🎉".repeat(50));
+            assert_eq!(mixed_tag.chars().count(), 55);
+
+            let result = sanitize_tags(vec![mixed_tag]);
+
+            // Should truncate to 50 characters
+            assert_eq!(result[0].chars().count(), MAX_TAG_LENGTH);
+            // Should be "hello" + 45 emojis
+            assert_eq!(result[0], format!("hello{}", "🎉".repeat(45)));
+        }
+
+        #[test]
+        fn enforces_max_tags_count() {
+            let tags: Vec<String> = (0..30).map(|i| format!("tag{}", i)).collect();
+            let result = sanitize_tags(tags);
+            assert_eq!(result.len(), MAX_TAGS_COUNT);
+        }
+
+        #[test]
+        fn strips_control_characters() {
+            let result = sanitize_tags(vec!["react\x00".to_string(), "front\x0Aend".to_string()]);
+            assert_eq!(result, vec!["react", "frontend"]);
+        }
+
+        #[test]
+        fn preserves_unicode() {
+            let result = sanitize_tags(vec!["日本語".to_string(), "emoji🎉".to_string()]);
+            assert_eq!(result, vec!["日本語", "emoji🎉"]);
+        }
+
+        #[test]
+        fn handles_mixed_case_duplicates_after_normalization() {
+            let result = sanitize_tags(vec![
+                "Backend".to_string(),
+                "frontend".to_string(),
+                "BACKEND".to_string(),
+                "FrontEnd".to_string(),
+            ]);
+            assert_eq!(result, vec!["backend", "frontend"]);
+        }
+    }
+
+    mod tag_sanitization_integration_tests {
+        use super::*;
+
+        #[test]
+        fn create_template_sanitizes_tags() {
+            let (db, _dir) = create_test_db();
+            let template = db.create_template(CreateTemplateInput {
+                name: "Test".to_string(),
+                description: None,
+                schema_xml: "<folder name=\"test\"/>".to_string(),
+                variables: HashMap::new(),
+                variable_validation: HashMap::new(),
+                icon_color: None,
+                is_favorite: false,
+                tags: vec!["  React  ".to_string(), "TYPESCRIPT".to_string(), "react".to_string()],
+            }).unwrap();
+
+            // Should be normalized: lowercase, trimmed, deduplicated
+            assert_eq!(template.tags, vec!["react", "typescript"]);
+        }
+
+        #[test]
+        fn update_template_tags_sanitizes_input() {
+            let (db, _dir) = create_test_db();
+            let template = db.create_template(create_test_template_input("Test")).unwrap();
+
+            let updated = db.update_template_tags(
+                &template.id,
+                vec!["  NEW  ".to_string(), "Tags".to_string(), "new".to_string()]
+            ).unwrap().unwrap();
+
+            assert_eq!(updated.tags, vec!["new", "tags"]);
         }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2035,6 +2035,9 @@ pub struct TemplateExport {
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub variable_validation: HashMap<String, ValidationRule>,
     pub icon_color: Option<String>,
+    /// Tags for categorization (optional, for backwards compatibility)
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
 }
 
 /// Type of export file - single template or bundle
@@ -2205,6 +2208,7 @@ fn cmd_create_template(
     variables: HashMap<String, String>,
     variable_validation: Option<HashMap<String, ValidationRule>>,
     icon_color: Option<String>,
+    tags: Option<Vec<String>>,
 ) -> Result<Template, String> {
     let state = state.lock().map_err(|e| e.to_string())?;
     state
@@ -2217,6 +2221,7 @@ fn cmd_create_template(
             variable_validation: variable_validation.unwrap_or_default(),
             icon_color,
             is_favorite: false,
+            tags: tags.unwrap_or_default(),
         })
         .map_err(|e| e.to_string())
 }
@@ -2264,6 +2269,29 @@ fn cmd_use_template(state: State<Mutex<AppState>>, id: String) -> Result<Option<
     let state = state.lock().map_err(|e| e.to_string())?;
     state.db.increment_use_count(&id).map_err(|e| e.to_string())?;
     state.db.get_template(&id).map_err(|e| e.to_string())
+}
+
+#[cfg(feature = "tauri-app")]
+#[tauri::command]
+fn cmd_update_template_tags(
+    state: State<Mutex<AppState>>,
+    id: String,
+    tags: Vec<String>,
+) -> Result<Option<Template>, String> {
+    let state = state.lock().map_err(|e| e.to_string())?;
+    state.db.update_template_tags(&id, tags).map_err(|e| e.to_string())
+}
+
+/// Get all unique tags across all templates.
+///
+/// Note: Currently not called by the frontend UI, which derives tags client-side
+/// from the templates list for instant filtering. Kept for potential future use
+/// (e.g., direct API access, external integrations).
+#[cfg(feature = "tauri-app")]
+#[tauri::command]
+fn cmd_get_all_tags(state: State<Mutex<AppState>>) -> Result<Vec<String>, String> {
+    let state = state.lock().map_err(|e| e.to_string())?;
+    state.db.get_all_tags().map_err(|e| e.to_string())
 }
 
 /// Check if an IPv4 address is private/internal
@@ -2440,6 +2468,7 @@ fn import_templates_from_json_internal(
             variable_validation,
             icon_color: template_export.icon_color,
             is_favorite: false,
+            tags: template_export.tags,
         };
 
         match db.create_template(input) {
@@ -2471,6 +2500,7 @@ fn cmd_export_template(
         variables: if include_variables { Some(template.variables) } else { None },
         variable_validation: if include_variables { template.variable_validation } else { HashMap::new() },
         icon_color: template.icon_color,
+        tags: template.tags,
     };
 
     let export_file = TemplateExportFile {
@@ -2516,6 +2546,7 @@ fn cmd_export_templates_bulk(
             variables: if include_variables { Some(t.variables) } else { None },
             variable_validation: if include_variables { t.variable_validation } else { HashMap::new() },
             icon_color: t.icon_color,
+            tags: t.tags,
         })
         .collect();
 
@@ -3289,6 +3320,8 @@ pub fn run() {
             cmd_delete_template,
             cmd_toggle_favorite,
             cmd_use_template,
+            cmd_update_template_tags,
+            cmd_get_all_tags,
             cmd_export_template,
             cmd_export_templates_bulk,
             cmd_import_templates_from_json,
@@ -3569,6 +3602,7 @@ mod tests {
                     variables: None,
                     variable_validation: HashMap::new(),
                     icon_color: None,
+                    tags: Vec::new(),
                 }),
                 templates: None,
             };

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -518,3 +518,56 @@ export const LoaderIcon = ({ className, size = 24 }: IconProps) => (
     <line x1="16.24" y1="7.76" x2="19.07" y2="4.93" />
   </svg>
 );
+
+export const SearchIcon = ({ className, size = 24 }: IconProps) => (
+  <svg
+    className={className}
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <circle cx="11" cy="11" r="8" />
+    <line x1="21" y1="21" x2="16.65" y2="16.65" />
+  </svg>
+);
+
+export const TagIcon = ({ className, size = 24 }: IconProps) => (
+  <svg
+    className={className}
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z" />
+    <line x1="7" y1="7" x2="7.01" y2="7" />
+  </svg>
+);
+
+export const ArrowUpIcon = ({ className, size = 24 }: IconProps) => (
+  <svg
+    className={className}
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M12 5v14M5 12l7-7 7 7" />
+  </svg>
+);

--- a/src/components/TagInput.tsx
+++ b/src/components/TagInput.tsx
@@ -1,0 +1,273 @@
+import { useState, useRef, useEffect, useCallback, useId, useMemo } from "react";
+import { XIcon } from "./Icons";
+
+/**
+ * Maximum length for a single tag (in characters, not bytes).
+ * NOTE: This constant is duplicated in src-tauri/src/database.rs for server-side validation.
+ * If you change this value, update the Rust constant to match.
+ */
+const MAX_TAG_LENGTH = 50;
+/**
+ * Maximum number of tags per template.
+ * NOTE: This constant is duplicated in src-tauri/src/database.rs for server-side validation.
+ * If you change this value, update the Rust constant to match.
+ */
+const MAX_TAGS_COUNT = 20;
+/** Delay before hiding suggestions on blur (allows click to register) */
+const BLUR_DELAY_MS = 200;
+/** Duration to display rejection message */
+const REJECTION_DISPLAY_MS = 1500;
+
+/** Validation rejection reasons */
+type RejectionReason = "empty" | "too_long" | "max_count" | "duplicate" | null;
+
+interface TagInputProps {
+  tags: string[];
+  onChange: (tags: string[]) => void;
+  suggestions?: string[];
+  placeholder?: string;
+  disabled?: boolean;
+}
+
+export const TagInput = ({
+  tags,
+  onChange,
+  suggestions = [],
+  placeholder = "Add tags...",
+  disabled = false,
+}: TagInputProps) => {
+  const [input, setInput] = useState("");
+  const [showSuggestions, setShowSuggestions] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(-1);
+  const [rejectionReason, setRejectionReason] = useState<RejectionReason>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const blurTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const rejectionTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Unique ID for accessibility (avoids duplicate IDs with multiple TagInput instances)
+  const suggestionsId = useId();
+
+  // Cleanup timeouts on unmount to prevent memory leak
+  useEffect(() => {
+    return () => {
+      if (blurTimeoutRef.current) {
+        clearTimeout(blurTimeoutRef.current);
+      }
+      if (rejectionTimeoutRef.current) {
+        clearTimeout(rejectionTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const filteredSuggestions = useMemo(
+    () =>
+      suggestions
+        .filter(
+          (s) => !tags.includes(s) && s.toLowerCase().includes(input.toLowerCase())
+        )
+        .slice(0, 5),
+    [suggestions, tags, input]
+  );
+
+  // Reset selection when suggestions change
+  useEffect(() => {
+    setSelectedIndex(-1);
+  }, [filteredSuggestions, input]);
+
+  const showRejection = useCallback((reason: RejectionReason) => {
+    setRejectionReason(reason);
+    if (rejectionTimeoutRef.current) {
+      clearTimeout(rejectionTimeoutRef.current);
+    }
+    rejectionTimeoutRef.current = setTimeout(() => {
+      setRejectionReason(null);
+    }, REJECTION_DISPLAY_MS);
+  }, []);
+
+  const addTag = useCallback((tag: string): boolean => {
+    const normalized = tag.trim().toLowerCase();
+
+    // Validation with feedback
+    if (!normalized) {
+      setInput("");
+      return false;
+    }
+    // Use spread operator to count characters, not bytes (for multi-byte UTF-8 safety)
+    if ([...normalized].length > MAX_TAG_LENGTH) {
+      showRejection("too_long");
+      return false;
+    }
+    if (tags.length >= MAX_TAGS_COUNT) {
+      showRejection("max_count");
+      return false;
+    }
+    if (tags.includes(normalized)) {
+      showRejection("duplicate");
+      setInput("");
+      return false;
+    }
+
+    onChange([...tags, normalized]);
+    setInput("");
+    setSelectedIndex(-1);
+    inputRef.current?.focus();
+    return true;
+  }, [tags, onChange, showRejection]);
+
+  const removeTag = (tag: string): void => {
+    onChange(tags.filter((t) => t !== tag));
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    const hasSuggestions = showSuggestions && filteredSuggestions.length > 0;
+
+    if (e.key === "ArrowDown" && hasSuggestions) {
+      e.preventDefault();
+      setSelectedIndex((prev) =>
+        prev < filteredSuggestions.length - 1 ? prev + 1 : 0
+      );
+    } else if (e.key === "ArrowUp" && hasSuggestions) {
+      e.preventDefault();
+      setSelectedIndex((prev) =>
+        prev > 0 ? prev - 1 : filteredSuggestions.length - 1
+      );
+    } else if (e.key === "Enter" || e.key === ",") {
+      e.preventDefault();
+      // If a suggestion is selected, use that; otherwise use input
+      if (hasSuggestions && selectedIndex >= 0) {
+        addTag(filteredSuggestions[selectedIndex]);
+      } else if (input.trim()) {
+        addTag(input);
+      }
+    } else if (e.key === "Tab" && hasSuggestions && selectedIndex >= 0) {
+      e.preventDefault();
+      addTag(filteredSuggestions[selectedIndex]);
+    } else if (e.key === "Backspace" && !input && tags.length > 0) {
+      removeTag(tags[tags.length - 1]);
+    } else if (e.key === "Escape") {
+      setShowSuggestions(false);
+      setSelectedIndex(-1);
+    }
+  };
+
+  const handleBlur = () => {
+    if (blurTimeoutRef.current) {
+      clearTimeout(blurTimeoutRef.current);
+    }
+    blurTimeoutRef.current = setTimeout(() => {
+      setShowSuggestions(false);
+      setSelectedIndex(-1);
+    }, BLUR_DELAY_MS);
+  };
+
+  const handleSuggestionClick = (suggestion: string) => {
+    // Reset selection before attempting to add (ensures consistent state)
+    setSelectedIndex(-1);
+    addTag(suggestion);
+  };
+
+  const getRejectionMessage = (): string | null => {
+    switch (rejectionReason) {
+      case "too_long":
+        return `Max ${MAX_TAG_LENGTH} characters`;
+      case "max_count":
+        return `Max ${MAX_TAGS_COUNT} tags`;
+      case "duplicate":
+        return "Tag already exists";
+      default:
+        return null;
+    }
+  };
+
+  const rejectionMessage = getRejectionMessage();
+
+  return (
+    <div className="relative">
+      <div
+        className={`mac-input flex flex-wrap gap-1 min-h-[32px] p-1.5 transition-opacity ${
+          disabled ? "opacity-50 cursor-not-allowed bg-mac-bg-hover" : ""
+        } ${rejectionReason ? "animate-shake border-system-red" : ""}`}
+      >
+        {tags.map((tag) => (
+          <span
+            key={tag}
+            className={`inline-flex items-center gap-1 px-2 py-0.5 bg-accent/10 text-accent text-mac-xs rounded ${
+              disabled ? "opacity-70" : ""
+            }`}
+          >
+            {tag}
+            {!disabled && (
+              <button
+                type="button"
+                onClick={() => removeTag(tag)}
+                className="hover:text-accent/70"
+                aria-label={`Remove tag ${tag}`}
+              >
+                <XIcon size={10} />
+              </button>
+            )}
+          </span>
+        ))}
+        <input
+          ref={inputRef}
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onFocus={() => setShowSuggestions(true)}
+          onBlur={handleBlur}
+          onKeyDown={handleKeyDown}
+          placeholder={tags.length === 0 ? placeholder : ""}
+          disabled={disabled}
+          maxLength={MAX_TAG_LENGTH}
+          className="flex-1 min-w-[80px] bg-transparent outline-none text-mac-sm disabled:cursor-not-allowed"
+          aria-label="Add tag"
+          aria-expanded={showSuggestions && filteredSuggestions.length > 0}
+          aria-haspopup="listbox"
+          aria-controls={showSuggestions ? suggestionsId : undefined}
+          aria-activedescendant={
+            selectedIndex >= 0 ? `${suggestionsId}-option-${selectedIndex}` : undefined
+          }
+          role="combobox"
+          aria-autocomplete="list"
+        />
+      </div>
+
+      {/* Rejection feedback message */}
+      {rejectionMessage && (
+        <div
+          className="absolute right-0 top-full mt-1 px-2 py-1 text-mac-xs text-system-red bg-system-red/10 rounded"
+          role="alert"
+          aria-live="assertive"
+        >
+          {rejectionMessage}
+        </div>
+      )}
+
+      {showSuggestions && filteredSuggestions.length > 0 && !disabled && (
+        <div
+          id={suggestionsId}
+          className="absolute z-10 w-full mt-1 bg-card-bg border border-border-muted rounded-mac shadow-mac overflow-hidden"
+          role="listbox"
+          aria-label="Tag suggestions"
+        >
+          {filteredSuggestions.map((suggestion, index) => (
+            <button
+              key={suggestion}
+              id={`${suggestionsId}-option-${index}`}
+              type="button"
+              role="option"
+              aria-selected={index === selectedIndex}
+              onClick={() => handleSuggestionClick(suggestion)}
+              onMouseEnter={() => setSelectedIndex(index)}
+              className={`w-full px-3 py-1.5 text-left text-mac-sm transition-colors ${
+                index === selectedIndex
+                  ? "bg-accent/10 text-accent"
+                  : "hover:bg-mac-bg-hover"
+              }`}
+            >
+              {suggestion}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/index.css
+++ b/src/index.css
@@ -287,6 +287,22 @@ body {
   animation: pulse 1.5s ease-in-out infinite;
 }
 
+@keyframes shake {
+  0%, 100% {
+    transform: translateX(0);
+  }
+  10%, 30%, 50%, 70%, 90% {
+    transform: translateX(-2px);
+  }
+  20%, 40%, 60%, 80% {
+    transform: translateX(2px);
+  }
+}
+
+.animate-shake {
+  animation: shake 0.4s ease-in-out;
+}
+
 /* Focus ring for accessibility */
 .mac-focus-ring:focus-visible {
   outline: none;

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -139,6 +139,7 @@ export interface Template {
   use_count: number;
   created_at: string;
   updated_at: string;
+  tags: string[];
 }
 
 export interface TemplateExport {
@@ -147,7 +148,12 @@ export interface TemplateExport {
   schema_xml: string;
   variables?: Record<string, string>;
   icon_color: string | null;
+  tags?: string[];
 }
+
+// Template filter/sort types
+export type TemplateSortField = "name" | "created_at" | "use_count" | "updated_at";
+export type SortOrder = "asc" | "desc";
 
 export interface TemplateExportFile {
   version: string;
@@ -338,6 +344,12 @@ export interface AppState {
   templates: Template[];
   templatesLoading: boolean;
 
+  // Template filtering
+  templateSearchQuery: string;
+  templateSelectedTags: string[];
+  templateSortBy: TemplateSortField;
+  templateSortOrder: SortOrder;
+
   // Settings
   settings: Settings;
   settingsLoading: boolean;
@@ -372,6 +384,11 @@ export interface AppState {
   setValidationErrors: (errors: ValidationError[]) => void;
   setTemplates: (templates: Template[]) => void;
   setTemplatesLoading: (loading: boolean) => void;
+  setTemplateSearchQuery: (query: string) => void;
+  setTemplateSelectedTags: (tags: string[]) => void;
+  toggleTemplateTag: (tag: string) => void;
+  setTemplateSortBy: (sortBy: TemplateSortField) => void;
+  setTemplateSortOrder: (order: SortOrder) => void;
   setSettings: (settings: Settings) => void;
   setSettingsLoading: (loading: boolean) => void;
   updateSetting: <K extends keyof Settings>(key: K, value: Settings[K]) => void;


### PR DESCRIPTION
- Add tags field to templates with backend sanitization (lowercase, trim, dedup, length/count limits, control char stripping)
- Add full-text search across template names and descriptions
- Add tag-based filtering with AND logic
- Add sorting by name, created date, usage count, and last updated
- Create reusable TagInput component with autocomplete suggestions
- Add database migration for existing installs
- Update CLI import/export to support tags
- Add comprehensive Rust tests (34 new tests)

Closes #10 