### PR TITLE
Add keyboard shortcuts for power users (#12)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,11 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { LeftPanel } from "./components/LeftPanel";
 import { TreePreview } from "./components/TreePreview";
 import { RightPanel } from "./components/RightPanel";
 import { Footer } from "./components/Footer";
 import { SettingsModal } from "./components/SettingsModal";
 import { useAppStore } from "./store/appStore";
+import { useKeyboardShortcuts } from "./hooks";
 import { api } from "./lib/api";
 import type { Settings, ThemeMode, AccentColor } from "./types/schema";
 import { DEFAULT_SETTINGS } from "./types/schema";
@@ -14,7 +15,22 @@ function App() {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [isInitialized, setIsInitialized] = useState(false);
   const [initError, setInitError] = useState<string | null>(null);
-  const { setSettings, setOutputPath, setProjectName, createNewSchema } = useAppStore();
+  const [importExportModalOpen, setImportExportModalOpen] = useState(false);
+  const { setSettings, setOutputPath, setProjectName, createNewSchema, showDiffModal, schemaContent } = useAppStore();
+
+  // Ref for search input (passed to LeftPanel)
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  // Check if any modal is open (used to disable shortcuts)
+  const isModalOpen = settingsOpen || showDiffModal || importExportModalOpen;
+
+  // Initialize keyboard shortcuts
+  // Note: Escape key is handled by individual modals, not here
+  useKeyboardShortcuts({
+    searchInputRef,
+    isModalOpen,
+    hasSchema: !!schemaContent,
+  });
 
   // Initialize the API and load settings on mount
   useEffect(() => {
@@ -125,7 +141,10 @@ function App() {
   return (
     <div className="bg-mac-bg min-h-screen flex flex-col">
       <div className="flex-1 grid grid-cols-[280px_1fr_300px] border-t border-border-muted">
-        <LeftPanel />
+        <LeftPanel
+          searchInputRef={searchInputRef}
+          onImportExportModalChange={setImportExportModalOpen}
+        />
         <TreePreview />
         <RightPanel />
       </div>

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,1 @@
+export * from "./shortcuts";

--- a/src/constants/shortcuts.ts
+++ b/src/constants/shortcuts.ts
@@ -1,0 +1,77 @@
+/**
+ * Keyboard shortcut event names used for cross-component communication.
+ * Centralized here to prevent typos and enable easy refactoring.
+ *
+ * Event ownership (which component listens):
+ * - CREATE_STRUCTURE: RightPanel
+ * - OPEN_FILE: LeftPanel
+ * - SAVE_TEMPLATE: LeftPanel
+ *
+ * Note: Escape key is handled by individual modals (SettingsModal, DiffPreviewModal,
+ * ImportExportModal) rather than centrally, to avoid double-firing issues.
+ */
+export const SHORTCUT_EVENTS = {
+  CREATE_STRUCTURE: "shortcut:create-structure",
+  OPEN_FILE: "shortcut:open-file",
+  SAVE_TEMPLATE: "shortcut:save-template",
+} as const;
+
+/**
+ * Type for Navigator with userAgentData (not yet in all TS libs)
+ */
+interface NavigatorUAData {
+  platform?: string;
+}
+
+type NavigatorWithUAData = Navigator & {
+  userAgentData?: NavigatorUAData;
+};
+
+/**
+ * Detect if the current platform is macOS.
+ * Uses modern userAgentData API with fallback to userAgent string matching.
+ * Computed once at module load since platform doesn't change during session.
+ */
+function detectMacPlatform(): boolean {
+  if (typeof navigator === "undefined") return false;
+
+  // Modern API (Chromium-based browsers)
+  const nav = navigator as NavigatorWithUAData;
+  if (nav.userAgentData?.platform) {
+    return nav.userAgentData.platform === "macOS";
+  }
+
+  // Fallback to userAgent string matching
+  return /Mac|iPod|iPhone|iPad/.test(navigator.userAgent);
+}
+
+/** Cached platform detection result - computed once at module load */
+const IS_MAC = detectMacPlatform();
+
+/**
+ * Keyboard shortcut display labels for tooltips and help text.
+ * Mac format uses symbols, Windows/Linux uses text.
+ */
+const SHORTCUT_LABELS_MAC = {
+  CREATE_STRUCTURE: "\u2318\u21A9", // ⌘↩
+  OPEN_FILE: "\u2318O", // ⌘O
+  SAVE_TEMPLATE: "\u2318S", // ⌘S
+  FOCUS_SEARCH: "\u2318F", // ⌘F
+} as const;
+
+const SHORTCUT_LABELS_OTHER = {
+  CREATE_STRUCTURE: "Ctrl+Enter",
+  OPEN_FILE: "Ctrl+O",
+  SAVE_TEMPLATE: "Ctrl+S",
+  FOCUS_SEARCH: "Ctrl+F",
+} as const;
+
+export type ShortcutKey = keyof typeof SHORTCUT_LABELS_MAC;
+
+/**
+ * Get platform-appropriate shortcut label for tooltips.
+ * Uses cached platform detection for performance.
+ */
+export function getShortcutLabel(shortcut: ShortcutKey): string {
+  return IS_MAC ? SHORTCUT_LABELS_MAC[shortcut] : SHORTCUT_LABELS_OTHER[shortcut];
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export { useClickAwayEscape } from "./useClickAwayEscape";
 export { useDebounce } from "./useDebounce";
+export { useKeyboardShortcuts } from "./useKeyboardShortcuts";

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,111 @@
+import { useEffect, RefObject } from "react";
+import { SHORTCUT_EVENTS } from "../constants/shortcuts";
+
+interface UseKeyboardShortcutsOptions {
+  /** Ref to the search input for focus shortcut */
+  searchInputRef: RefObject<HTMLInputElement>;
+  /** Whether any modal is currently open */
+  isModalOpen: boolean;
+  /** Whether a schema is currently loaded (for save template shortcut) */
+  hasSchema: boolean;
+}
+
+/**
+ * Checks if the currently focused element is an input field
+ * where keyboard shortcuts should be disabled.
+ */
+function isInputFocused(): boolean {
+  const el = document.activeElement;
+  if (!el) return false;
+  const tag = el.tagName.toLowerCase();
+  return (
+    tag === "input" ||
+    tag === "textarea" ||
+    tag === "select" ||
+    (el as HTMLElement).isContentEditable
+  );
+}
+
+/**
+ * Centralized hook for managing global keyboard shortcuts.
+ *
+ * Event flow:
+ * - Cmd+Enter → SHORTCUT_EVENTS.CREATE_STRUCTURE → RightPanel.handleCreateRef
+ * - Cmd+O     → SHORTCUT_EVENTS.OPEN_FILE        → LeftPanel.handleSelectSchemaRef
+ * - Cmd+S     → SHORTCUT_EVENTS.SAVE_TEMPLATE    → LeftPanel.setIsSavingTemplate
+ * - Cmd+F     → (direct) searchInputRef.focus()   (no event, hence no FOCUS_SEARCH in SHORTCUT_EVENTS)
+ *
+ * Key comparison notes:
+ * - Letter keys use .toLowerCase() to handle CapsLock state
+ * - Special keys (Enter) use direct comparison as they're consistent
+ *
+ * Note: Escape key is handled by individual modals (SettingsModal, DiffPreviewModal,
+ * ImportExportModal) to avoid double-firing issues.
+ *
+ * Note: Arrow key navigation for templates is handled in LeftPanel
+ * as it requires component-local state.
+ */
+export function useKeyboardShortcuts({
+  searchInputRef,
+  isModalOpen,
+  hasSchema,
+}: UseKeyboardShortcutsOptions): void {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const isMod = event.metaKey || event.ctrlKey;
+
+      // Skip all shortcuts when modal is open
+      // Escape is handled by individual modals to avoid double-firing
+      if (isModalOpen) {
+        return;
+      }
+
+      // Skip shortcuts when in input fields (except Cmd+F for search)
+      // Letter keys use .toLowerCase() to handle CapsLock
+      if (isInputFocused() && !(isMod && event.key.toLowerCase() === "f")) {
+        return;
+      }
+
+      // Cmd/Ctrl + Enter: Create structure
+      // Special keys like Enter don't need toLowerCase()
+      if (isMod && event.key === "Enter") {
+        event.preventDefault();
+        window.dispatchEvent(new CustomEvent(SHORTCUT_EVENTS.CREATE_STRUCTURE));
+        return;
+      }
+
+      // Cmd/Ctrl + O: Open file picker
+      // Always available - allows replacing current schema with a new one
+      if (isMod && event.key.toLowerCase() === "o") {
+        event.preventDefault();
+        window.dispatchEvent(new CustomEvent(SHORTCUT_EVENTS.OPEN_FILE));
+        return;
+      }
+
+      // Cmd/Ctrl + S: Save as template (only when schema is loaded)
+      if (isMod && event.key.toLowerCase() === "s") {
+        // Only prevent default and handle if schema is loaded
+        // Otherwise let browser handle normally (e.g., save page dialog)
+        if (hasSchema) {
+          event.preventDefault();
+          window.dispatchEvent(new CustomEvent(SHORTCUT_EVENTS.SAVE_TEMPLATE));
+        }
+        // Always return to prevent falling through to other handlers,
+        // even when !hasSchema (lets browser handle Cmd+S normally)
+        return;
+      }
+
+      // Cmd/Ctrl + F: Focus search input
+      if (isMod && event.key.toLowerCase() === "f") {
+        event.preventDefault();
+        searchInputRef.current?.focus();
+        return;
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [searchInputRef, isModalOpen, hasSchema]);
+}


### PR DESCRIPTION
- Cmd/Ctrl+Enter: Create structure
- Cmd/Ctrl+O: Open file picker
- Cmd/Ctrl+S: Save as template (when schema loaded)
- Cmd/Ctrl+F: Focus template search
- Arrow keys: Navigate template list
- Enter/Space: Select template

Features:
- Centralized shortcut handling via useKeyboardShortcuts hook
- Platform-aware labels (⌘ on Mac, Ctrl+ on Windows/Linux)
- Shortcuts disabled when modals open or in input fields
- Full accessibility: ARIA listbox pattern for template navigation
- Tooltips showing keyboard shortcuts on buttons

Closes #12 