### PR TITLE
Implement undo/redo operations (#27)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,7 @@ function App() {
   const [isInitialized, setIsInitialized] = useState(false);
   const [initError, setInitError] = useState<string | null>(null);
   const [importExportModalOpen, setImportExportModalOpen] = useState(false);
-  const { setSettings, setOutputPath, setProjectName, createNewSchema, showDiffModal, schemaContent } = useAppStore();
+  const { setSettings, setOutputPath, setProjectName, createNewSchema, showDiffModal, schemaContent, undo, redo, canUndo, canRedo } = useAppStore();
 
   // Ref for search input (passed to LeftPanel)
   const searchInputRef = useRef<HTMLInputElement>(null);
@@ -30,7 +30,27 @@ function App() {
     searchInputRef,
     isModalOpen,
     hasSchema: !!schemaContent,
+    canUndo: canUndo(),
+    canRedo: canRedo(),
   });
+
+  // Listen for undo/redo shortcut events
+  useEffect(() => {
+    const handleUndo = () => {
+      if (canUndo()) undo();
+    };
+    const handleRedo = () => {
+      if (canRedo()) redo();
+    };
+
+    window.addEventListener("shortcut:undo", handleUndo);
+    window.addEventListener("shortcut:redo", handleRedo);
+
+    return () => {
+      window.removeEventListener("shortcut:undo", handleUndo);
+      window.removeEventListener("shortcut:redo", handleRedo);
+    };
+  }, [undo, redo, canUndo, canRedo]);
 
   // Initialize the API and load settings on mount
   useEffect(() => {

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -327,6 +327,24 @@ export const TrashIcon = ({ className, size = 24 }: IconProps) => (
   </svg>
 );
 
+export const UndoIcon = ({ className, size = 24 }: IconProps) => (
+  <svg
+    className={className}
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M3 7v6h6" />
+    <path d="M21 17a9 9 0 0 0-9-9 9 9 0 0 0-6 2.3L3 13" />
+  </svg>
+);
+
 export const SaveIcon = ({ className, size = 24 }: IconProps) => (
   <svg
     className={className}

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -235,6 +235,7 @@ export const RightPanel = () => {
               templateName,
               foldersCreated: result.summary.folders_created,
               filesCreated: result.summary.files_created,
+              createdPaths: result.created_paths || [],
             });
 
             // Refresh the recent projects list

--- a/src/constants/shortcuts.ts
+++ b/src/constants/shortcuts.ts
@@ -14,6 +14,8 @@ export const SHORTCUT_EVENTS = {
   CREATE_STRUCTURE: "shortcut:create-structure",
   OPEN_FILE: "shortcut:open-file",
   SAVE_TEMPLATE: "shortcut:save-template",
+  UNDO: "shortcut:undo",
+  REDO: "shortcut:redo",
 } as const;
 
 /**
@@ -57,6 +59,8 @@ const SHORTCUT_LABELS_MAC = {
   OPEN_FILE: "\u2318O", // ⌘O
   SAVE_TEMPLATE: "\u2318S", // ⌘S
   FOCUS_SEARCH: "\u2318F", // ⌘F
+  UNDO: "\u2318Z", // ⌘Z
+  REDO: "\u21E7\u2318Z", // ⇧⌘Z
 } as const;
 
 const SHORTCUT_LABELS_OTHER = {
@@ -64,6 +68,8 @@ const SHORTCUT_LABELS_OTHER = {
   OPEN_FILE: "Ctrl+O",
   SAVE_TEMPLATE: "Ctrl+S",
   FOCUS_SEARCH: "Ctrl+F",
+  UNDO: "Ctrl+Z",
+  REDO: "Ctrl+Y",
 } as const;
 
 export type ShortcutKey = keyof typeof SHORTCUT_LABELS_MAC;

--- a/src/lib/adapters/tauri/index.ts
+++ b/src/lib/adapters/tauri/index.ts
@@ -37,6 +37,7 @@ import type {
   ValidationError,
   ValidationRule,
   CreateResult,
+  RevertResult,
   DiffResult,
   ImportResult,
   DuplicateStrategy,
@@ -57,6 +58,7 @@ interface RustRecentProject {
   folders_created: number;
   files_created: number;
   created_at: string;
+  created_paths: string[];
 }
 
 /** Convert Rust snake_case RecentProject to TypeScript camelCase */
@@ -73,6 +75,7 @@ function toRecentProject(p: RustRecentProject): RecentProject {
     foldersCreated: p.folders_created,
     filesCreated: p.files_created,
     createdAt: p.created_at,
+    createdPaths: p.created_paths || [],
   };
 }
 
@@ -274,6 +277,7 @@ class TauriDatabaseAdapter implements DatabaseAdapter {
       templateName: input.templateName,
       foldersCreated: input.foldersCreated,
       filesCreated: input.filesCreated,
+      createdPaths: input.createdPaths,
     });
     return toRecentProject(p);
   }
@@ -364,6 +368,10 @@ class TauriStructureCreatorAdapter implements StructureCreatorAdapter {
       variables,
       overwrite,
     });
+  }
+
+  async revertStructure(paths: string[]): Promise<RevertResult> {
+    return invoke<RevertResult>("cmd_revert_structure", { paths });
   }
 }
 

--- a/src/lib/adapters/types.ts
+++ b/src/lib/adapters/types.ts
@@ -9,6 +9,7 @@ import type {
   ValidationError,
   ValidationRule,
   CreateResult,
+  RevertResult,
   DiffResult,
   ImportResult,
   DuplicateStrategy,
@@ -124,6 +125,8 @@ export interface CreateRecentProjectInput {
   templateName: string | null;
   foldersCreated: number;
   filesCreated: number;
+  /** Paths that were created (for revert functionality) */
+  createdPaths: string[];
 }
 
 export interface DatabaseAdapter {
@@ -227,6 +230,11 @@ export interface StructureCreatorAdapter {
     variables: Record<string, string>,
     overwrite: boolean
   ): Promise<DiffResult>;
+
+  /**
+   * Revert (delete) previously created structure.
+   */
+  revertStructure(paths: string[]): Promise<RevertResult>;
 }
 
 // ============================================================================

--- a/src/lib/adapters/web/index.ts
+++ b/src/lib/adapters/web/index.ts
@@ -19,6 +19,7 @@ import type {
   ValidationError,
   ValidationRule,
   CreateResult,
+  RevertResult,
   DiffResult,
   ParseWithInheritanceResult,
 } from "../../../types/schema";
@@ -228,6 +229,15 @@ class WebStructureCreatorAdapter implements StructureCreatorAdapter {
     }
 
     return generateDiffPreview(tree, rootHandle, variables, overwrite);
+  }
+
+  async revertStructure(_paths: string[]): Promise<RevertResult> {
+    // Web mode doesn't support reverting structures due to File System Access API limitations
+    return {
+      files_deleted: 0,
+      folders_deleted: 0,
+      errors: ["Reverting structures is not supported in web mode. Please use the desktop app for this feature."],
+    };
   }
 }
 

--- a/src/lib/adapters/web/indexeddb.ts
+++ b/src/lib/adapters/web/indexeddb.ts
@@ -673,6 +673,7 @@ export class IndexedDBAdapter implements DatabaseAdapter {
       foldersCreated: input.foldersCreated,
       filesCreated: input.filesCreated,
       createdAt: timestamp,
+      createdPaths: input.createdPaths,
     };
 
     return new Promise((resolve, reject) => {

--- a/src/lib/adapters/web/structure-creator.ts
+++ b/src/lib/adapters/web/structure-creator.ts
@@ -153,6 +153,8 @@ export const createStructureFromTree = async (
     logs: context.logs,
     summary: context.summary,
     hook_results: [],
+    // Web mode doesn't track created paths (File System Access API doesn't provide persistent paths)
+    created_paths: [],
   };
 };
 

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -154,6 +154,8 @@ export interface RecentProject {
   foldersCreated: number;
   filesCreated: number;
   createdAt: string;
+  /** Paths that were created (for revert functionality) */
+  createdPaths: string[];
 }
 
 export type TemplateSortOption =
@@ -255,6 +257,14 @@ export interface CreateResult {
   logs: BackendLogEntry[];
   summary: ResultSummary;
   hook_results: HookResult[];
+  /** Paths that were created (for revert functionality) */
+  created_paths: string[];
+}
+
+export interface RevertResult {
+  files_deleted: number;
+  folders_deleted: number;
+  errors: string[];
 }
 
 // ============================================================================


### PR DESCRIPTION
- Add confirmation dialog before deleting schema nodes
- Centralize undo/redo keyboard shortcuts (Cmd+Z, Cmd+Y/Cmd+Shift+Z)
- Add backend revert command to delete created structures
- Track created file paths in recent projects for revert functionality
- Add revert button to recent projects with confirmation dialog
- Add UndoIcon component for revert UI

This implements the remaining items from the undo/redo operations roadmap:
- Revert last created structure
- Confirmation for destructive undos