### PR TITLE
feat: replace %BASE% with %PROJECT_NAME% as built-in variable

### DIFF
--- a/apps/desktop/src-tauri/src/bin/cli.rs
+++ b/apps/desktop/src-tauri/src/bin/cli.rs
@@ -101,6 +101,10 @@ enum Commands {
         #[arg(short, long)]
         output: PathBuf,
 
+        /// Project name (sets %PROJECT_NAME% variable)
+        #[arg(short, long)]
+        name: Option<String>,
+
         /// Variable substitutions (can be used multiple times)
         /// Format: NAME=value
         #[arg(long = "var", value_parser = parse_variable)]
@@ -618,6 +622,7 @@ fn cmd_create(
     template: Option<String>,
     schema: Option<String>,
     output: PathBuf,
+    name: Option<String>,
     vars: Vec<(String, String)>,
     dry_run: bool,
     overwrite: bool,
@@ -715,7 +720,7 @@ fn cmd_create(
         );
     }
 
-    match create_structure_from_tree(&tree, &output_str, &variables, dry_run, overwrite) {
+    match create_structure_from_tree(&tree, &output_str, &variables, dry_run, overwrite, name.as_deref()) {
         Ok(result) => print_result(&result, json_output, quiet),
         Err(e) => CliResult::Error(e),
     }
@@ -1112,11 +1117,12 @@ fn main() {
             template,
             schema,
             output,
+            name,
             vars,
             dry_run,
             overwrite,
             json,
-        } => cmd_create(template, schema, output, vars, dry_run, overwrite, json, quiet),
+        } => cmd_create(template, schema, output, name, vars, dry_run, overwrite, json, quiet),
 
         Commands::Templates { action } => match action {
             TemplateAction::List { json } => cmd_templates_list(json, quiet),

--- a/apps/desktop/src-tauri/src/validation.rs
+++ b/apps/desktop/src-tauri/src/validation.rs
@@ -136,8 +136,11 @@ pub fn check_undefined_variables(
     for var_ref in refs {
         // base_name is already in %NAME% format
         if !variables.contains_key(&var_ref.base_name) {
-            // Special case: skip DATE variable as it's handled internally
-            if var_ref.base_name == "%DATE%" {
+            // Special case: skip built-in variables as they're handled internally
+            if matches!(
+                var_ref.base_name.as_str(),
+                "%DATE%" | "%YEAR%" | "%MONTH%" | "%DAY%" | "%PROJECT_NAME%"
+            ) {
                 continue;
             }
 
@@ -414,6 +417,17 @@ mod tests {
     fn test_check_undefined_variables_date_special() {
         // DATE is a special variable that's handled internally
         let content = r#"<file name="%DATE:format(YYYY-MM-DD)%.txt" />"#;
+        let variables = HashMap::new();
+
+        let result = check_undefined_variables(content, &variables);
+        assert!(result.is_valid);
+        assert!(result.warnings.is_empty());
+    }
+
+    #[test]
+    fn test_check_undefined_variables_year_month_day_special() {
+        // YEAR, MONTH, DAY are built-in variables handled internally
+        let content = r#"<file name="report-%YEAR%-%MONTH%-%DAY%.txt" />"#;
         let variables = HashMap::new();
 
         let result = check_undefined_variables(content, &variables);

--- a/apps/desktop/src/components/RightPanel.tsx
+++ b/apps/desktop/src/components/RightPanel.tsx
@@ -269,6 +269,7 @@ export const RightPanel = () => {
           variables: varsMap,
           dryRun: isDryRun,
           overwrite,
+          projectName,
         });
       } else if (effectiveTree) {
         result = await api.structureCreator.createStructureFromTree(effectiveTree, {
@@ -276,6 +277,7 @@ export const RightPanel = () => {
           variables: varsMap,
           dryRun: isDryRun,
           overwrite,
+          projectName,
         });
       } else {
         throw new Error("No schema available");

--- a/apps/desktop/src/components/TreePreview.tsx
+++ b/apps/desktop/src/components/TreePreview.tsx
@@ -30,7 +30,7 @@ interface TreeItemProps {
 
 const TreeItem = ({ node, depth, projectName }: TreeItemProps) => {
   const displayName =
-    node.name === "%BASE%" ? projectName : node.name.replace(/%BASE%/g, projectName);
+    node.name === "%PROJECT_NAME%" ? projectName : node.name.replace(/%PROJECT_NAME%/g, projectName);
 
   const isFolder = node.type === "folder";
   const isIf = node.type === "if";

--- a/apps/desktop/src/components/VisualSchemaEditor.tsx
+++ b/apps/desktop/src/components/VisualSchemaEditor.tsx
@@ -345,9 +345,9 @@ const EditableTreeItem = ({
   }, [showContextMenu]);
 
   const displayName =
-    node.name === "%BASE%"
+    node.name === "%PROJECT_NAME%"
       ? projectName
-      : node.name.replace(/%BASE%/g, projectName);
+      : node.name.replace(/%PROJECT_NAME%/g, projectName);
 
   const hasChildren = node.children && node.children.length > 0;
 
@@ -953,7 +953,7 @@ export const VisualSchemaEditor = () => {
     try {
       const xml = await api.schema.exportSchemaXml(schemaTree);
 
-      const defaultName = schemaTree.root.name === "%BASE%"
+      const defaultName = schemaTree.root.name === "%PROJECT_NAME%"
         ? `${projectName}-schema.xml`
         : `${schemaTree.root.name}-schema.xml`;
 
@@ -1090,9 +1090,9 @@ export const VisualSchemaEditor = () => {
                   case "repeat":
                     return `repeat ${draggedNode.repeat_count || DEFAULT_REPEAT_COUNT} as %${draggedNode.repeat_as || DEFAULT_REPEAT_AS}%`;
                   default:
-                    return draggedNode.name === "%BASE%"
+                    return draggedNode.name === "%PROJECT_NAME%"
                       ? projectName
-                      : draggedNode.name.replace(/%BASE%/g, projectName);
+                      : draggedNode.name.replace(/%PROJECT_NAME%/g, projectName);
                 }
               };
 

--- a/apps/desktop/src/lib/adapters/tauri/index.ts
+++ b/apps/desktop/src/lib/adapters/tauri/index.ts
@@ -340,6 +340,7 @@ class TauriStructureCreatorAdapter implements StructureCreatorAdapter {
       variables: options.variables,
       dryRun: options.dryRun,
       overwrite: options.overwrite,
+      projectName: options.projectName,
     });
   }
 
@@ -353,6 +354,7 @@ class TauriStructureCreatorAdapter implements StructureCreatorAdapter {
       variables: options.variables,
       dryRun: options.dryRun,
       overwrite: options.overwrite,
+      projectName: options.projectName,
     });
   }
 

--- a/apps/desktop/src/lib/adapters/types.ts
+++ b/apps/desktop/src/lib/adapters/types.ts
@@ -203,6 +203,7 @@ export interface CreateStructureOptions {
   variables: Record<string, string>;
   dryRun: boolean;
   overwrite: boolean;
+  projectName?: string;
 }
 
 export interface StructureCreatorAdapter {

--- a/apps/desktop/src/lib/adapters/web/index.ts
+++ b/apps/desktop/src/lib/adapters/web/index.ts
@@ -206,10 +206,16 @@ class WebStructureCreatorAdapter implements StructureCreatorAdapter {
       );
     }
 
+    // Inject built-in variables (project name), allowing user overrides
+    const allVariables = { ...options.variables };
+    if (options.projectName && !allVariables["%PROJECT_NAME%"]) {
+      allVariables["%PROJECT_NAME%"] = options.projectName;
+    }
+
     return createStructureFromTree(
       tree,
       rootHandle,
-      options.variables,
+      allVariables,
       options.dryRun,
       options.overwrite
     );

--- a/apps/desktop/src/store/appStore.ts
+++ b/apps/desktop/src/store/appStore.ts
@@ -171,9 +171,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   isWatching: false,
 
   // Variables
-  variables: [
-    { name: "%DATE%", value: new Date().toISOString().split("T")[0] },
-  ],
+  variables: [],
   validationErrors: [],
 
   // Templates
@@ -481,7 +479,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     const newRoot: SchemaNode = {
       id: generateNodeId(),
       type: "folder",
-      name: "%BASE%",
+      name: "%PROJECT_NAME%",
       children: [],
     };
 

--- a/apps/web/content/docs/api/schema.mdx
+++ b/apps/web/content/docs/api/schema.mdx
@@ -132,7 +132,19 @@ Variables use the `%NAME%` syntax and are substituted at creation time.
 </folder>
 ```
 
-See [Variables & Transforms](/docs/guides/variables) for details on transforms and built-in variables.
+### Built-in Variables
+
+These variables are always available:
+
+| Variable | Description |
+|----------|-------------|
+| `%PROJECT_NAME%` | Project name from the UI |
+| `%DATE%` | Current date (YYYY-MM-DD) |
+| `%YEAR%` | Current year |
+| `%MONTH%` | Current month (01-12) |
+| `%DAY%` | Current day (01-31) |
+
+See [Variables & Transforms](/docs/guides/variables) for details on transforms, date formatting, and validation.
 
 ## Complete Example
 

--- a/apps/web/content/docs/guides/variables.mdx
+++ b/apps/web/content/docs/guides/variables.mdx
@@ -67,15 +67,45 @@ Apply transformations to format variable values:
 
 ## Built-in Variables
 
-Structure Creator provides built-in variables:
+Structure Creator provides built-in variables that are automatically available without needing to define them:
 
 | Variable | Description | Example |
 |----------|-------------|---------|
+| `%PROJECT_NAME%` | The project name from the UI | my-awesome-project |
 | `%DATE%` | Current date (ISO) | 2024-01-15 |
 | `%DATE:FORMAT%` | Formatted date | See below |
 | `%YEAR%` | Current year | 2024 |
 | `%MONTH%` | Current month (01-12) | 01 |
 | `%DAY%` | Current day (01-31) | 15 |
+
+### Project Name Variable
+
+The `%PROJECT_NAME%` variable is special—it's automatically set from the "Project Name" field in the UI. This is the recommended way to name your root folder:
+
+```xml
+<folder name="%PROJECT_NAME%">
+  <file name="README.md">
+# %PROJECT_NAME%
+
+Welcome to %PROJECT_NAME%!
+  </file>
+</folder>
+```
+
+When you enter "my-awesome-project" in the Project Name field, the folder will be created with that name, and all references to `%PROJECT_NAME%` in your schema will be replaced.
+
+You can also apply transforms to the project name:
+
+```xml
+<file name="package.json">
+{
+  "name": "%PROJECT_NAME:kebab-case%",
+  "displayName": "%PROJECT_NAME:PascalCase%"
+}
+</file>
+```
+
+**Note:** If you define `%PROJECT_NAME%` as a custom variable, your value will override the built-in project name.
 
 ### Date Formats
 

--- a/design/structure-creator-ui.html
+++ b/design/structure-creator-ui.html
@@ -907,7 +907,7 @@
                 <div class="section-title">Variables</div>
                 <div class="variables-list">
                     <div class="variable-item">
-                        <span class="variable-name">%BASE%</span>
+                        <span class="variable-name">%PROJECT_NAME%</span>
                         <span class="variable-arrow">-></span>
                         <span class="variable-value">my-awesome-project</span>
                     </div>

--- a/examples/conditional-schema.xml
+++ b/examples/conditional-schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<folder name="%BASE%">
+<folder name="%PROJECT_NAME%">
   <folder name="src">
     <if var="USE_TYPESCRIPT">
       <file name="index.ts" />

--- a/examples/repeat-schema.xml
+++ b/examples/repeat-schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<folder name="%BASE%">
+<folder name="%PROJECT_NAME%">
   <!-- Generate multiple module folders dynamically -->
   <repeat count="%NUM_MODULES%" as="i">
     <folder name="module_%i%">

--- a/schema.xml
+++ b/schema.xml
@@ -1,4 +1,4 @@
-<folder name='%BASE%'>
+<folder name='%PROJECT_NAME%'>
 	<folder name='assets' />
 	<folder name='docs' />
 	<folder name='release'>


### PR DESCRIPTION
- Replace all occurrences of %BASE% with %PROJECT_NAME% throughout codebase
- Make %PROJECT_NAME% a built-in variable injected by the Rust backend
- Add project_name parameter to create structure commands (Tauri + CLI)
- Add --name flag to CLI for setting project name
- Update web adapter to inject %PROJECT_NAME% into variables
- Add %PROJECT_NAME% to validation's built-in variable skip list
- Add tests for %PROJECT_NAME% injection and user override
- Update web documentation with %PROJECT_NAME% details
- Update example schemas to use %PROJECT_NAME%