### PR TITLE
feat(desktop): VariableName module (ADR-0001)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,3 +90,17 @@ Structure Creator is a Tauri 2.0 desktop application that generates folder/file 
 - **Tauri IPC**: Frontend uses `@tauri-apps/api` invoke() to call Rust commands
 - **File Downloads**: XML files can have `url` attribute; Rust downloads content using ureq
 - **Dry Run Mode**: Preview changes without creating files (handled in Rust)
+
+## Agent skills
+
+### Issue tracker
+
+Issues and PRDs live as GitHub issues in `eddiemoore/StructureCreator`, managed via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Five canonical triage roles use default label strings (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context — one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/apps/desktop/src/utils/variableName.test.ts
+++ b/apps/desktop/src/utils/variableName.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { asVariableName, toToken, type VariableName } from "./variableName";
+
+describe("variableName", () => {
+  describe("asVariableName", () => {
+    it("strips surrounding % delimiters", () => {
+      expect(asVariableName("%NAME%")).toBe("NAME");
+    });
+
+    it("is idempotent on an already-clean name", () => {
+      expect(asVariableName("NAME")).toBe("NAME");
+      expect(asVariableName(asVariableName("%NAME%"))).toBe("NAME");
+    });
+  });
+
+  describe("toToken", () => {
+    it("wraps a clean name in % delimiters", () => {
+      expect(toToken(asVariableName("NAME"))).toBe("%NAME%");
+    });
+
+    it("round-trips with asVariableName", () => {
+      const name = asVariableName("NAME");
+      expect(asVariableName(toToken(name))).toBe(name);
+    });
+  });
+
+  it("rejects a raw string where a VariableName is expected (compile-time)", () => {
+    // @ts-expect-error - a plain string is not assignable to VariableName
+    const name: VariableName = "NAME";
+    expect(typeof name).toBe("string");
+  });
+});

--- a/apps/desktop/src/utils/variableName.ts
+++ b/apps/desktop/src/utils/variableName.ts
@@ -1,0 +1,24 @@
+/**
+ * The variable-name convention (ADR-0001).
+ *
+ * A **Variable name** is the canonical clean identifier (e.g. `NAME`). A
+ * **Variable token** is its delimited edge form (`%NAME%`) as it appears in
+ * schema text and on the IPC wire. This module owns the conversion between the
+ * two so callers never re-derive the `%` convention.
+ */
+
+/** A clean, canonical variable name. Constructed only via {@link asVariableName}. */
+export type VariableName = string & { readonly __brand: "VariableName" };
+
+/**
+ * Normalize a raw string to a clean {@link VariableName}, stripping a single
+ * surrounding `%` delimiter. Idempotent.
+ */
+export const asVariableName = (raw: string): VariableName =>
+  raw.replace(/^%|%$/g, "") as VariableName;
+
+/**
+ * Produce the {@link VariableName}'s **Variable token** (`%NAME%`) for an
+ * outbound edge (IPC to the native backend, or template-substitution scan).
+ */
+export const toToken = (name: VariableName): string => `%${name}%`;

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+This repo is **single-context**: one `CONTEXT.md` + `docs/adr/` at the repo root.
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+For reference, a multi-context repo (signalled by `CONTEXT-MAP.md` at the root) looks like:
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
Implements #94 — the first slice of ADR-0001.

## What

A frontend module owning the variable-name convention:
- branded `VariableName` type (constructible only via the normalizer)
- `asVariableName(raw)` — strips a single surrounding `%`, idempotent
- `toToken(name)` — produces the `%NAME%` Variable token for outbound edges

No callers are wired in this slice (that is #98). The strip matches the existing `/^%|%$/g` used at the ~15 sites this will later supersede, so behaviour is identical to what it replaces.

## Tests

- `asVariableName` strips delimiters + is idempotent
- `toToken` wraps and round-trips with `asVariableName`
- compile-time: a raw string is not assignable to `VariableName` (`@ts-expect-error`, validated by `tsc`)

5/5 module tests pass; 329/329 full desktop suite; `tsc --noEmit` exits 0.

Closes #94