### PR TITLE
feat(desktop): adopt clean-canonical variable names (ADR-0001)

### DIFF
--- a/apps/desktop/src/components/LeftPanel.test.tsx
+++ b/apps/desktop/src/components/LeftPanel.test.tsx
@@ -469,8 +469,8 @@ describe("LeftPanel", () => {
         renderLeftPanel();
         await waitForDataLoad();
 
-        expect(screen.getByText("%PROJECT_NAME%")).toBeInTheDocument();
-        expect(screen.getByText("%VERSION%")).toBeInTheDocument();
+        expect(screen.getByText("PROJECT_NAME")).toBeInTheDocument();
+        expect(screen.getByText("VERSION")).toBeInTheDocument();
       });
 
       it("displays variable values in inputs", async () => {
@@ -594,7 +594,7 @@ describe("LeftPanel", () => {
         await waitForDataLoad();
 
         // Find the remove button (appears on hover)
-        const variableContainer = screen.getByText("%PROJECT_NAME%").closest("div");
+        const variableContainer = screen.getByText("PROJECT_NAME").closest("div");
         const removeButton = within(variableContainer!.parentElement!).getByTitle("Remove variable");
         fireEvent.click(removeButton);
 
@@ -608,7 +608,7 @@ describe("LeftPanel", () => {
         renderLeftPanel();
         await waitForDataLoad();
 
-        const settingsButton = screen.getByLabelText(/configure validation for %PROJECT_NAME%/i);
+        const settingsButton = screen.getByLabelText(/configure validation for PROJECT_NAME/i);
         fireEvent.click(settingsButton);
 
         expect(screen.getByText("Validation Rules")).toBeInTheDocument();
@@ -620,7 +620,7 @@ describe("LeftPanel", () => {
         renderLeftPanel();
         await waitForDataLoad();
 
-        fireEvent.click(screen.getByLabelText(/configure validation for %PROJECT_NAME%/i));
+        fireEvent.click(screen.getByLabelText(/configure validation for PROJECT_NAME/i));
 
         const requiredCheckbox = screen.getByRole("checkbox");
         fireEvent.click(requiredCheckbox);
@@ -633,7 +633,7 @@ describe("LeftPanel", () => {
         renderLeftPanel();
         await waitForDataLoad();
 
-        fireEvent.click(screen.getByLabelText(/configure validation for %PROJECT_NAME%/i));
+        fireEvent.click(screen.getByLabelText(/configure validation for PROJECT_NAME/i));
         expect(screen.getByText("Validation Rules")).toBeInTheDocument();
 
         fireEvent.click(screen.getByRole("button", { name: /done/i }));

--- a/apps/desktop/src/lib/adapters/tauri/index.ts
+++ b/apps/desktop/src/lib/adapters/tauri/index.ts
@@ -5,6 +5,7 @@
 
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { toTokenKeys } from "../../../utils/variableName";
 import { open, save } from "@tauri-apps/plugin-dialog";
 import {
   readTextFile,
@@ -351,7 +352,7 @@ class TauriStructureCreatorAdapter implements StructureCreatorAdapter {
     return invoke<CreateResult>("cmd_create_structure", {
       content,
       outputPath: options.outputPath,
-      variables: options.variables,
+      variables: toTokenKeys(options.variables),
       dryRun: options.dryRun,
       overwrite: options.overwrite,
       projectName: options.projectName,
@@ -365,7 +366,7 @@ class TauriStructureCreatorAdapter implements StructureCreatorAdapter {
     return invoke<CreateResult>("cmd_create_structure_from_tree", {
       tree,
       outputPath: options.outputPath,
-      variables: options.variables,
+      variables: toTokenKeys(options.variables),
       dryRun: options.dryRun,
       overwrite: options.overwrite,
       projectName: options.projectName,
@@ -381,7 +382,7 @@ class TauriStructureCreatorAdapter implements StructureCreatorAdapter {
     return invoke<DiffResult>("cmd_generate_diff_preview", {
       tree,
       outputPath,
-      variables,
+      variables: toTokenKeys(variables),
       overwrite,
     });
   }
@@ -407,8 +408,8 @@ class TauriValidationAdapter implements ValidationAdapter {
     rules: Record<string, ValidationRule>
   ): Promise<ValidationError[]> {
     return invoke<ValidationError[]>("cmd_validate_variables", {
-      variables,
-      rules,
+      variables: toTokenKeys(variables),
+      rules: toTokenKeys(rules),
     });
   }
 
@@ -418,7 +419,7 @@ class TauriValidationAdapter implements ValidationAdapter {
   ): Promise<SchemaValidationResult> {
     return invoke<SchemaValidationResult>("cmd_validate_schema", {
       content,
-      variables,
+      variables: toTokenKeys(variables),
     });
   }
 }

--- a/apps/desktop/src/lib/adapters/web/index.ts
+++ b/apps/desktop/src/lib/adapters/web/index.ts
@@ -41,6 +41,7 @@ import { WebFileSystemAdapter, getHandleRegistry } from "./filesystem";
 import { parseSchema, exportSchemaXml, scanDirectoryToSchema } from "./schema-parser";
 import { createStructureFromTree, generateDiffPreview } from "./structure-creator";
 import { validateVariables as validateVars, extractVariablesFromContent } from "./transforms";
+import { toTokenKeys } from "../../../utils/variableName";
 import { WebTemplateImportExportAdapter } from "./template-io";
 import { scanZipToSchema } from "./zip-utils";
 
@@ -116,8 +117,10 @@ const injectBuiltInVariables = (
     allVariables["%PROJECT_NAME%"] = projectName;
   }
 
-  // User-provided variables override built-ins
-  for (const [key, value] of Object.entries(variables)) {
+  // User-provided variables override built-ins. They arrive as clean
+  // canonical names (ADR-0001); the web engine looks variables up by their
+  // token form, so tokenize the keys at this adapter boundary.
+  for (const [key, value] of Object.entries(toTokenKeys(variables))) {
     allVariables[key] = value;
   }
 
@@ -319,7 +322,7 @@ class WebValidationAdapter implements ValidationAdapter {
     variables: Record<string, string>,
     rules: Record<string, ValidationRule>
   ): Promise<ValidationError[]> {
-    return validateVars(variables, rules);
+    return validateVars(toTokenKeys(variables), toTokenKeys(rules));
   }
 
   async validateSchema(

--- a/apps/desktop/src/store/appStore.variables.test.ts
+++ b/apps/desktop/src/store/appStore.variables.test.ts
@@ -15,9 +15,9 @@ describe("appStore variable handling", () => {
 
       const state = useAppStore.getState();
       expect(state.variables).toHaveLength(2);
-      expect(state.variables[0].name).toBe("%CLIENT_NAME%");
+      expect(state.variables[0].name).toBe("CLIENT_NAME");
       expect(state.variables[0].value).toBe("");
-      expect(state.variables[1].name).toBe("%PROJECT_TYPE%");
+      expect(state.variables[1].name).toBe("PROJECT_TYPE");
       expect(state.variables[1].value).toBe("");
     });
 
@@ -30,7 +30,7 @@ describe("appStore variable handling", () => {
       const state = useAppStore.getState();
       expect(state.variables).toHaveLength(2);
       expect(state.variables[0].value).toBe("Existing Value"); // Preserved
-      expect(state.variables[1].name).toBe("%NEW_VAR%");
+      expect(state.variables[1].name).toBe("NEW_VAR");
     });
   });
 
@@ -49,7 +49,7 @@ describe("appStore variable handling", () => {
 
       const state = useAppStore.getState();
       expect(state.variables).toHaveLength(1);
-      expect(state.variables[0].name).toBe("%CLIENT_NAME%");
+      expect(state.variables[0].name).toBe("CLIENT_NAME");
       expect(state.variables[0].description).toBe("The client company name");
       expect(state.variables[0].placeholder).toBe("Enter client name...");
       expect(state.variables[0].example).toBe("Acme Corp");
@@ -173,7 +173,7 @@ describe("appStore variable handling", () => {
 
       const state = useAppStore.getState();
       expect(state.variables).toHaveLength(1);
-      expect(state.variables[0].name).toBe("%UNMATCHED_VAR%");
+      expect(state.variables[0].name).toBe("UNMATCHED_VAR");
       expect(state.variables[0].description).toBeUndefined();
     });
 
@@ -209,6 +209,46 @@ describe("appStore variable handling", () => {
       const stateAfter = useAppStore.getState();
       // Variables array should be the same reference (optimization working)
       expect(stateAfter.variables).toBe(variablesBefore);
+    });
+  });
+
+  describe("clean-canonical names (ADR-0001)", () => {
+    it("stores a clean name even when added with a token, and updates + clears errors by clean name", () => {
+      const store = useAppStore.getState();
+      store.addVariable("%CLIENT_NAME%", "");
+      store.setValidationErrors([
+        { variable_name: "CLIENT_NAME", message: "required" },
+      ]);
+
+      store.updateVariable("CLIENT_NAME", "Acme");
+
+      const state = useAppStore.getState();
+      expect(state.variables[0].name).toBe("CLIENT_NAME");
+      expect(state.variables[0].value).toBe("Acme");
+      expect(state.validationErrors).toHaveLength(0);
+    });
+
+    it("normalizes delimited names on setVariables (e.g. loaded from persisted data)", () => {
+      useAppStore.getState().setVariables([
+        { name: "%CLIENT_NAME%", value: "Acme" },
+        { name: "REGION", value: "us" },
+      ]);
+
+      const state = useAppStore.getState();
+      expect(state.variables.map((v) => v.name)).toEqual(["CLIENT_NAME", "REGION"]);
+      expect(state.variables[0].value).toBe("Acme");
+    });
+
+    it("removes a variable and clears its error when given a token form", () => {
+      const store = useAppStore.getState();
+      store.setVariables([{ name: "FOO", value: "x" }]);
+      store.setValidationErrors([{ variable_name: "FOO", message: "bad" }]);
+
+      store.removeVariable("%FOO%");
+
+      const state = useAppStore.getState();
+      expect(state.variables).toHaveLength(0);
+      expect(state.validationErrors).toHaveLength(0);
     });
   });
 });

--- a/apps/desktop/src/store/slices/variablesSlice.ts
+++ b/apps/desktop/src/store/slices/variablesSlice.ts
@@ -1,5 +1,6 @@
 import type { StateCreator } from "zustand";
 import type { Variable, ValidationRule, ValidationError, VariableDefinition } from "../../types/schema";
+import { asVariableName } from "../../utils/variableName";
 
 export interface VariablesSlice {
   variables: Variable[];
@@ -17,15 +18,21 @@ export const createVariablesSlice: StateCreator<VariablesSlice, [], [], Variable
   variables: [],
   validationErrors: [],
 
-  setVariables: (variables) => set({ variables }),
+  setVariables: (variables) =>
+    set({
+      // Normalize to clean canonical names on entry (ADR-0001); idempotent,
+      // so delimited names loaded from persisted data are accepted.
+      variables: variables.map((v) => ({ ...v, name: asVariableName(v.name) })),
+    }),
 
   updateVariable: (name, value) =>
     set((state) => {
-      // Clean name for comparison (validation errors use clean names without % delimiters)
-      const cleanName = name.replace(/^%|%$/g, "");
+      // Variable names are canonical in clean form (ADR-0001); normalize the
+      // incoming name so a token or clean name both match.
+      const cleanName = asVariableName(name);
       return {
         variables: state.variables.map((v) =>
-          v.name === name ? { ...v, value } : v
+          v.name === cleanName ? { ...v, value } : v
         ),
         // Clear validation errors when value changes
         validationErrors: state.validationErrors.filter(
@@ -36,8 +43,7 @@ export const createVariablesSlice: StateCreator<VariablesSlice, [], [], Variable
 
   addVariable: (name, value) =>
     set((state) => {
-      // Ensure name has % wrapping
-      const varName = name.startsWith("%") ? name : `%${name}%`;
+      const varName = asVariableName(name);
       // Check if variable already exists
       if (state.variables.some((v) => v.name === varName)) {
         return state;
@@ -49,10 +55,9 @@ export const createVariablesSlice: StateCreator<VariablesSlice, [], [], Variable
 
   removeVariable: (name) =>
     set((state) => {
-      // Clean name for comparison (validation errors use clean names without % delimiters)
-      const cleanName = name.replace(/^%|%$/g, "");
+      const cleanName = asVariableName(name);
       return {
-        variables: state.variables.filter((v) => v.name !== name),
+        variables: state.variables.filter((v) => v.name !== cleanName),
         validationErrors: state.validationErrors.filter(
           (e) => e.variable_name !== cleanName
         ),
@@ -61,12 +66,11 @@ export const createVariablesSlice: StateCreator<VariablesSlice, [], [], Variable
 
   mergeDetectedVariables: (detectedVarNames, definitions) =>
     set((state) => {
-      // Create a map of definitions by name (with % wrapper to match variable names)
+      // Definitions and detected names are keyed by clean canonical name.
       const defMap = new Map<string, VariableDefinition>();
       if (definitions) {
         for (const def of definitions) {
-          // Variable names in state have % wrapper, definition names don't
-          defMap.set(`%${def.name}%`, def);
+          defMap.set(asVariableName(def.name), def);
         }
       }
 
@@ -74,6 +78,7 @@ export const createVariablesSlice: StateCreator<VariablesSlice, [], [], Variable
 
       // Create new variables with definitions applied
       const newVariables = detectedVarNames
+        .map((name) => asVariableName(name))
         .filter((name) => !existingNames.has(name))
         .map((name) => {
           const def = defMap.get(name);

--- a/apps/desktop/src/utils/variableName.test.ts
+++ b/apps/desktop/src/utils/variableName.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { asVariableName, toToken, type VariableName } from "./variableName";
+import { asVariableName, toToken, toTokenKeys, type VariableName } from "./variableName";
 
 describe("variableName", () => {
   describe("asVariableName", () => {
@@ -21,6 +21,19 @@ describe("variableName", () => {
     it("round-trips with asVariableName", () => {
       const name = asVariableName("NAME");
       expect(asVariableName(toToken(name))).toBe(name);
+    });
+  });
+
+  describe("toTokenKeys", () => {
+    it("rewrites every map key to its token form, preserving values", () => {
+      expect(toTokenKeys({ NAME: "a", REGION: "b" })).toEqual({
+        "%NAME%": "a",
+        "%REGION%": "b",
+      });
+    });
+
+    it("is idempotent on already-tokenized keys", () => {
+      expect(toTokenKeys({ "%NAME%": "a" })).toEqual({ "%NAME%": "a" });
     });
   });
 

--- a/apps/desktop/src/utils/variableName.ts
+++ b/apps/desktop/src/utils/variableName.ts
@@ -22,3 +22,16 @@ export const asVariableName = (raw: string): VariableName =>
  * outbound edge (IPC to the native backend, or template-substitution scan).
  */
 export const toToken = (name: VariableName): string => `%${name}%`;
+
+/**
+ * Rewrite a variable-name-keyed map to its **Variable token** keys (`%NAME%`),
+ * for outbound IPC to the native backend whose lookups use the token form.
+ * Idempotent on keys that are already tokens.
+ */
+export const toTokenKeys = <V>(map: Record<string, V>): Record<string, V> => {
+  const out: Record<string, V> = {};
+  for (const [key, value] of Object.entries(map)) {
+    out[toToken(asVariableName(key))] = value;
+  }
+  return out;
+};


### PR DESCRIPTION
Implements #98 (ADR-0001), building on the `VariableName` module from #94.

## What

- The store holds **clean** variable names; a token (`%NAME%`) can no longer enter it. Inbound edges (`addVariable`, `mergeDetectedVariables`, `setVariables`) normalize via `asVariableName` (idempotent, so persisted delimited data still loads — no migration).
- `updateVariable` / `removeVariable` compare clean directly — fixes the bug where a delimited/clean mismatch left a variable's validation error uncleared.
- The variable panel now displays the clean name.
- Each adapter tokenizes the variable map at its entry boundary via `toTokenKeys` (added to the `VariableName` module): the Tauri adapter for Rust's `format!("%{}%")` IPC lookup, the web adapter for its token-internal engine. `buildVariableMaps` stays clean.

## Refinement to ADR-0001

The ADR originally said the wrap lives only in the Tauri adapter and "the web adapter wraps nothing." Implementation revealed the web creation engine is token-internal end-to-end (built-in injection, substitution, repeat-loop vars, generators); converting it would be a large, risky rewrite. Refined decision (recorded in ADR-0001, landed separately on main): store + `buildVariableMaps` are clean, and **both** adapters tokenize at their entry boundary. Clean-canonical applies to the Variable-list/store domain — where the bug lived — not to each engine's internal substitution keys.

## Tests

- New: clean storage + update/remove clear errors by clean name (the regression); `setVariables` normalizes delimited (persisted) keys; `toTokenKeys` rewrites keys + is idempotent.
- Updated: existing slice + LeftPanel tests now feed delimited inputs (proving normalization) and assert clean output/labels.

Full desktop suite: **334/334**. `tsc --noEmit`: clean. Branded `VariableName` enforcement on `Variable.name` is deferred to #103.

Closes #98