### PR TITLE
feat: golden-vector contract harness for transforms (ADR-0002)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 9
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build shared package
+        run: pnpm build:shared
+
+      # Frontend (web target) tests, including the golden-vector contract.
+      - name: Run frontend tests
+        run: pnpm test:run
+
+      # Backend (native target) tests, including the golden-vector contract.
+      # Both suites consume fixtures/, so a cross-target divergence fails here.
+      - name: Run Rust tests
+        run: cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml

--- a/apps/desktop/src-tauri/src/transforms.rs
+++ b/apps/desktop/src-tauri/src/transforms.rs
@@ -938,4 +938,31 @@ mod tests {
         let vars = extract_variables_from_content(content);
         assert!(vars.is_empty());
     }
+
+    // Golden-vector contract (ADR-0002): the transform fixtures are the single
+    // cross-target spec, consumed by both this Rust suite and the web TS suite.
+    #[test]
+    fn test_transforms_match_golden_contract() {
+        #[derive(serde::Deserialize)]
+        struct Case {
+            transform: String,
+            input: String,
+            expected: String,
+        }
+
+        let fixture = include_str!("../../../../fixtures/transforms.json");
+        let cases: Vec<Case> = serde_json::from_str(fixture).expect("valid fixture JSON");
+        assert!(!cases.is_empty(), "transform fixture must contain cases");
+
+        for case in cases {
+            let transform = parse_transform(&case.transform, None)
+                .unwrap_or_else(|_| panic!("unknown transform in fixture: {}", case.transform));
+            let got = apply_transform(&case.input, &transform);
+            assert_eq!(
+                got, case.expected,
+                "transform `{}` on {:?}: expected {:?}, got {:?}",
+                case.transform, case.input, case.expected, got
+            );
+        }
+    }
 }

--- a/apps/desktop/src/contract/transforms.contract.test.ts
+++ b/apps/desktop/src/contract/transforms.contract.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, it, expect } from "vitest";
+import { applyTransform } from "../lib/adapters/web/transforms";
+
+/**
+ * Golden-vector contract (ADR-0002). The transform fixtures are the single
+ * cross-target spec, consumed by both this web TS suite and the Rust suite.
+ * A divergence between the two implementations fails one of them in CI.
+ */
+interface TransformCase {
+  transform: string;
+  input: string;
+  expected: string;
+}
+
+// vitest runs with cwd at the desktop package root (apps/desktop); the shared
+// fixtures live at the repo root.
+const fixturePath = resolve(process.cwd(), "../../fixtures/transforms.json");
+const cases: TransformCase[] = JSON.parse(readFileSync(fixturePath, "utf-8"));
+
+describe("transforms golden-vector contract", () => {
+  it("loads cases from the shared fixture", () => {
+    expect(cases.length).toBeGreaterThan(0);
+  });
+
+  it.each(cases)(
+    "$transform on '$input' -> '$expected'",
+    ({ transform, input, expected }) => {
+      expect(applyTransform(input, transform)).toBe(expected);
+    }
+  );
+});

--- a/apps/desktop/src/lib/adapters/web/transforms.ts
+++ b/apps/desktop/src/lib/adapters/web/transforms.ts
@@ -178,7 +178,7 @@ const formatDate = (dateStr: string, format: string): string => {
  * Parse and apply a transformation to a value.
  * Transformations are in the format: value|transform or value|transform(arg)
  */
-const applyTransform = (value: string, transform: string): string => {
+export const applyTransform = (value: string, transform: string): string => {
   // Check for format transform with argument
   const formatMatch = transform.match(/^format\((.+)\)$/);
   if (formatMatch) {

--- a/fixtures/transforms.json
+++ b/fixtures/transforms.json
@@ -1,0 +1,13 @@
+[
+  { "transform": "uppercase", "input": "hello", "expected": "HELLO" },
+  { "transform": "lowercase", "input": "HELLO", "expected": "hello" },
+  { "transform": "camelcase", "input": "hello world", "expected": "helloWorld" },
+  { "transform": "camelcase", "input": "hello_world", "expected": "helloWorld" },
+  { "transform": "pascalcase", "input": "hello world", "expected": "HelloWorld" },
+  { "transform": "kebab-case", "input": "helloWorld", "expected": "hello-world" },
+  { "transform": "snake_case", "input": "helloWorld", "expected": "hello_world" },
+  { "transform": "plural", "input": "cat", "expected": "cats" },
+  { "transform": "plural", "input": "bus", "expected": "buses" },
+  { "transform": "plural", "input": "city", "expected": "cities" },
+  { "transform": "length", "input": "hello", "expected": "5" }
+]


### PR DESCRIPTION
Implements #95 — the first tracer bullet for ADR-0002 (cross-target consistency).

## What

- `fixtures/transforms.json` — a language-neutral `[{transform, input, expected}]` spec, the single source of truth for variable-transform behaviour.
- **Rust** contract test (`transforms.rs`) `include_str!`s the fixture and runs every case through `parse_transform` + `apply_transform`.
- **Web TS** contract test (`src/contract/transforms.contract.test.ts`) reads the same fixture and runs each case through `applyTransform` (now exported).
- **CI** (`.github/workflows/ci.yml`, the repo's first test workflow) runs both suites on push/PR. A divergence between the two implementations fails the build.

Covers the shared transform set: upper/lower, camel/pascal, kebab/snake, plural, length.

## Verification

- Full desktop suite **346/346** (`tsc` clean); Rust **246/246**.
- Divergence check: corrupting a fixture value fails **both** suites locally — confirming the gate enforces, not just decorates.

## Notes

This lands the harness + transforms. The remaining ADR-0002 behaviours extend the same mechanism: #99 (templating), #100 (substitution + `%NAME%`), #101 (schema-structure semantics) — all now unblocked.

Closes #95