### PR TITLE
feat: golden-vector contract for substitution + %NAME% token (ADR-0002)

### DIFF
--- a/apps/desktop/src-tauri/src/transforms.rs
+++ b/apps/desktop/src-tauri/src/transforms.rs
@@ -939,6 +939,31 @@ mod tests {
         assert!(vars.is_empty());
     }
 
+    // Golden-vector contract (ADR-0002): pins both variable substitution and
+    // the `%NAME%` Variable-token convention across targets.
+    #[test]
+    fn test_substitution_matches_golden_contract() {
+        #[derive(serde::Deserialize)]
+        struct Case {
+            template: String,
+            variables: std::collections::HashMap<String, String>,
+            expected: String,
+        }
+
+        let fixture = include_str!("../../../../fixtures/substitution.json");
+        let cases: Vec<Case> = serde_json::from_str(fixture).expect("valid fixture JSON");
+        assert!(!cases.is_empty(), "substitution fixture must contain cases");
+
+        for case in cases {
+            let got = substitute_variables(&case.template, &case.variables);
+            assert_eq!(
+                got, case.expected,
+                "substitute_variables({:?}, {:?}): expected {:?}, got {:?}",
+                case.template, case.variables, case.expected, got
+            );
+        }
+    }
+
     // Golden-vector contract (ADR-0002): the transform fixtures are the single
     // cross-target spec, consumed by both this Rust suite and the web TS suite.
     #[test]

--- a/apps/desktop/src/contract/substitution.contract.test.ts
+++ b/apps/desktop/src/contract/substitution.contract.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, it, expect } from "vitest";
+import { substituteVariables } from "../lib/adapters/web/transforms";
+
+/**
+ * Golden-vector contract (ADR-0002). The substitution fixtures pin both
+ * variable substitution and the `%NAME%` Variable-token convention, consumed
+ * by both this web TS suite and the Rust suite.
+ */
+interface SubstitutionCase {
+  template: string;
+  variables: Record<string, string>;
+  expected: string;
+}
+
+const fixturePath = resolve(process.cwd(), "../../fixtures/substitution.json");
+const cases: SubstitutionCase[] = JSON.parse(readFileSync(fixturePath, "utf-8"));
+
+describe("substitution golden-vector contract", () => {
+  it("loads cases from the shared fixture", () => {
+    expect(cases.length).toBeGreaterThan(0);
+  });
+
+  it.each(cases)(
+    "$template -> $expected",
+    ({ template, variables, expected }) => {
+      expect(substituteVariables(template, variables)).toBe(expected);
+    }
+  );
+});

--- a/fixtures/substitution.json
+++ b/fixtures/substitution.json
@@ -1,0 +1,37 @@
+[
+  {
+    "template": "Hello %NAME%!",
+    "variables": { "%NAME%": "world" },
+    "expected": "Hello world!"
+  },
+  {
+    "template": "%FOO% and %BAR%",
+    "variables": { "%FOO%": "foo", "%BAR%": "bar" },
+    "expected": "foo and bar"
+  },
+  {
+    "template": "%X%-%X%",
+    "variables": { "%X%": "a" },
+    "expected": "a-a"
+  },
+  {
+    "template": "%NAME:uppercase%",
+    "variables": { "%NAME%": "hello" },
+    "expected": "HELLO"
+  },
+  {
+    "template": "%NAME:kebab-case%",
+    "variables": { "%NAME%": "helloWorld" },
+    "expected": "hello-world"
+  },
+  {
+    "template": "no variables here",
+    "variables": {},
+    "expected": "no variables here"
+  },
+  {
+    "template": "keep %MISSING% as-is",
+    "variables": {},
+    "expected": "keep %MISSING% as-is"
+  }
+]


### PR DESCRIPTION
Implements #100, extending the harness from #95 to variable substitution and pinning the `%NAME%` Variable-token convention across targets.

## What

- `fixtures/substitution.json` — `[{ template, variables, expected }]`, the cross-target spec for substitution.
- Rust contract test (`transforms.rs::test_substitution_matches_golden_contract`) runs the fixture through `substitute_variables`.
- TS contract test (`src/contract/substitution.contract.test.ts`) runs it through `substituteVariables`.
- CI gate from #95 already runs both — no workflow change.

Covers: plain substitution, multi-var, multi-occurrence of one variable, substitution with a transform (`%NAME:uppercase%`, `%NAME:kebab-case%`), unmatched tokens preserved, empty-template.

## Verification

- Full desktop suite **354/354** (`tsc` clean); Rust **247/247**.

Closes #100