### PR TITLE
feat: golden-vector contract for templating directives (ADR-0002)

### DIFF
--- a/apps/desktop/src-tauri/src/transforms.rs
+++ b/apps/desktop/src-tauri/src/transforms.rs
@@ -964,6 +964,32 @@ mod tests {
         }
     }
 
+    // Golden-vector contract (ADR-0002): pins the `{{if}}` / `{{for}}`
+    // templating directives across targets.
+    #[test]
+    fn test_templating_matches_golden_contract() {
+        #[derive(serde::Deserialize)]
+        struct Case {
+            template: String,
+            variables: std::collections::HashMap<String, String>,
+            expected: String,
+        }
+
+        let fixture = include_str!("../../../../fixtures/templating.json");
+        let cases: Vec<Case> = serde_json::from_str(fixture).expect("valid fixture JSON");
+        assert!(!cases.is_empty(), "templating fixture must contain cases");
+
+        for case in cases {
+            let got = crate::templating::process_template(&case.template, &case.variables)
+                .unwrap_or_else(|e| panic!("templating error on {:?}: {:?}", case.template, e));
+            assert_eq!(
+                got, case.expected,
+                "process_template({:?}, {:?}): expected {:?}, got {:?}",
+                case.template, case.variables, case.expected, got
+            );
+        }
+    }
+
     // Golden-vector contract (ADR-0002): the transform fixtures are the single
     // cross-target spec, consumed by both this Rust suite and the web TS suite.
     #[test]

--- a/apps/desktop/src/contract/templating.contract.test.ts
+++ b/apps/desktop/src/contract/templating.contract.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, it, expect } from "vitest";
+import { processTemplateOrThrow } from "@structure-creator/shared";
+
+/**
+ * Golden-vector contract (ADR-0002). The templating fixtures pin the
+ * `{{if}}` / `{{for}}` directives across targets, consumed by both this
+ * web TS suite (via the shared templating engine) and the Rust suite.
+ */
+interface TemplatingCase {
+  template: string;
+  variables: Record<string, string>;
+  expected: string;
+}
+
+const fixturePath = resolve(process.cwd(), "../../fixtures/templating.json");
+const cases: TemplatingCase[] = JSON.parse(readFileSync(fixturePath, "utf-8"));
+
+describe("templating golden-vector contract", () => {
+  it("loads cases from the shared fixture", () => {
+    expect(cases.length).toBeGreaterThan(0);
+  });
+
+  it.each(cases)(
+    "$template -> $expected",
+    ({ template, variables, expected }) => {
+      expect(processTemplateOrThrow(template, variables)).toBe(expected);
+    }
+  );
+});

--- a/fixtures/templating.json
+++ b/fixtures/templating.json
@@ -1,0 +1,32 @@
+[
+  {
+    "template": "{{if FLAG}}yes{{endif}}",
+    "variables": { "%FLAG%": "on" },
+    "expected": "yes"
+  },
+  {
+    "template": "{{if FLAG}}yes{{endif}}",
+    "variables": {},
+    "expected": ""
+  },
+  {
+    "template": "{{if FLAG}}yes{{else}}no{{endif}}",
+    "variables": { "%FLAG%": "on" },
+    "expected": "yes"
+  },
+  {
+    "template": "{{if FLAG}}yes{{else}}no{{endif}}",
+    "variables": {},
+    "expected": "no"
+  },
+  {
+    "template": "{{for x in LIST}}{{x}}-{{endfor}}",
+    "variables": { "%LIST%": "a,b,c" },
+    "expected": "a-b-c-"
+  },
+  {
+    "template": "{{for x in LIST}}{{if FLAG}}{{x}}{{endif}}{{endfor}}",
+    "variables": { "%LIST%": "a,b", "%FLAG%": "on" },
+    "expected": "ab"
+  }
+]


### PR DESCRIPTION
Implements #99, extending the harness from #95 to the `{{if}}` / `{{for}}` templating directives.

## What

- `fixtures/templating.json` — `[{ template, variables, expected }]`, the cross-target spec.
- Rust contract test (`transforms.rs::test_templating_matches_golden_contract`) runs each case through `process_template`.
- TS contract test (`src/contract/templating.contract.test.ts`) runs the same fixture through `processTemplateOrThrow` (from `@structure-creator/shared`).
- CI gate from #95 already runs both — no workflow change.

Covers: truthy/falsy `{{if}}`, `{{if}}`/`{{else}}` branches, `{{for}}` iteration (comma-split list), and `{{if}}` nested inside `{{for}}`.

## Verification

- Full desktop suite **353/353** (`tsc` clean); Rust **247/247**.

Closes #99