### PR TITLE
feat: golden-vector contract for schema-structure semantics (ADR-0002)

### DIFF
--- a/apps/desktop/src-tauri/src/structure_creator.rs
+++ b/apps/desktop/src-tauri/src/structure_creator.rs
@@ -1588,4 +1588,72 @@ mod tests {
             assert!(!folder_path.exists());
         }
     }
+
+    // Golden-vector contract (ADR-0002): pins schema-structure semantics
+    // (variable substitution in names, repeat expansion, condition eval)
+    // across targets. Runs the planning engine (`generate_diff_preview`) and
+    // collects the planned relative paths from the resulting DiffNode tree.
+    #[test]
+    fn test_schema_structure_matches_golden_contract() {
+        use std::collections::HashMap;
+
+        #[derive(serde::Deserialize)]
+        struct Case {
+            name: String,
+            tree: crate::schema::SchemaTree,
+            variables: HashMap<String, String>,
+            #[serde(rename = "expectedPaths")]
+            expected_paths: Vec<String>,
+        }
+
+        fn collect_paths(node: &crate::types::DiffNode, prefix: &str, out: &mut Vec<String>) {
+            let p = node
+                .path
+                .strip_prefix(prefix)
+                .unwrap_or(node.path.as_str())
+                .trim_start_matches('/');
+            if !p.is_empty() {
+                out.push(p.to_string());
+            }
+            if let Some(children) = &node.children {
+                for child in children {
+                    collect_paths(child, prefix, out);
+                }
+            }
+        }
+
+        let fixture = include_str!("../../../../fixtures/schema-structure.json");
+        let cases: Vec<Case> = serde_json::from_str(fixture).expect("valid fixture JSON");
+        assert!(!cases.is_empty(), "schema-structure fixture must contain cases");
+
+        for case in &cases {
+            // Output path does not need to exist; with no existing files the
+            // planner treats every item as a Create. Use a stable fake path so
+            // diff_preview's relative-to-output logic produces clean paths.
+            let result = crate::diff_preview::generate_diff_preview(
+                &case.tree,
+                "/sc-contract-101",
+                &case.variables,
+                false, // overwrite
+            )
+            .unwrap_or_else(|e| panic!("case '{}' failed: {}", case.name, e));
+
+            let mut paths: Vec<String> = Vec::new();
+            collect_paths(&result.root, "/sc-contract-101", &mut paths);
+            // The DiffNode tree wraps repeat/if blocks in virtual nodes that
+            // re-emit the parent path. Dedup so the contract sees the same
+            // unique path set both targets actually plan to create.
+            paths.sort();
+            paths.dedup();
+
+            let mut expected = case.expected_paths.clone();
+            expected.sort();
+
+            assert_eq!(
+                paths, expected,
+                "case '{}': paths mismatch",
+                case.name
+            );
+        }
+    }
 }

--- a/apps/desktop/src/contract/schema-structure.contract.test.ts
+++ b/apps/desktop/src/contract/schema-structure.contract.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, it, expect } from "vitest";
+import type { SchemaTree } from "@structure-creator/shared";
+import { expandTreeToPaths } from "../lib/adapters/web/expand-tree";
+
+/**
+ * Golden-vector contract (ADR-0002). The schema-structure fixtures pin
+ * structural semantics (variable substitution in names, repeat expansion,
+ * condition evaluation) across targets, consumed by both this web TS suite
+ * (via `expandTreeToPaths`) and the Rust suite (via `generate_diff_preview`).
+ */
+interface SchemaStructureCase {
+  name: string;
+  tree: SchemaTree;
+  variables: Record<string, string>;
+  expectedPaths: string[];
+}
+
+const fixturePath = resolve(
+  process.cwd(),
+  "../../fixtures/schema-structure.json"
+);
+const cases: SchemaStructureCase[] = JSON.parse(
+  readFileSync(fixturePath, "utf-8")
+);
+
+describe("schema-structure golden-vector contract", () => {
+  it("loads cases from the shared fixture", () => {
+    expect(cases.length).toBeGreaterThan(0);
+  });
+
+  it.each(cases)(
+    "$name",
+    ({ tree, variables, expectedPaths }) => {
+      const got = [...expandTreeToPaths(tree, variables)].sort();
+      const expected = [...expectedPaths].sort();
+      expect(got).toEqual(expected);
+    }
+  );
+});

--- a/apps/desktop/src/lib/adapters/web/expand-tree.ts
+++ b/apps/desktop/src/lib/adapters/web/expand-tree.ts
@@ -1,0 +1,128 @@
+import type { SchemaNode, SchemaTree } from "@structure-creator/shared";
+
+/**
+ * Case-preserving variable substitution for path/name expansion. Mirrors the
+ * Rust target's substitution: looks the captured name up verbatim, so a
+ * lowercase iteration var (`%i%`) resolves against a `%i%`-keyed entry. This
+ * is distinct from the web engine's `substituteVariables`, which uppercases
+ * the lookup key for user-facing tokens.
+ */
+const substituteInName = (
+  text: string,
+  variables: Record<string, string>
+): string =>
+  text.replace(
+    /%([A-Za-z_][A-Za-z0-9_]*)%/g,
+    (match, name) => variables[`%${name}%`] ?? match
+  );
+
+/**
+ * Pure tree expander: given a parsed schema and variable map, return the
+ * relative paths (folders + files) that would result from creating the
+ * structure. No filesystem access; mirrors the planning semantics used by
+ * the Rust target's `generate_diff_preview` so the golden-vector contract
+ * (ADR-0002, issue #101) can compare the two.
+ *
+ * Supports: folder, file, variable substitution in names, `<if var="X">`
+ * conditional evaluation (truthy = non-empty and not "false"/"0"), `<else>`
+ * sibling of the immediately preceding `<if>`, and `<repeat count as>`
+ * iteration with the iteration variable available to children.
+ */
+export const expandTreeToPaths = (
+  tree: SchemaTree,
+  variables: Record<string, string>
+): string[] => {
+  const paths: string[] = [];
+  walk(tree.root, "", paths, variables);
+  return paths;
+};
+
+const walk = (
+  node: SchemaNode,
+  prefix: string,
+  paths: string[],
+  variables: Record<string, string>
+): void => {
+  const name = substituteInName(node.name, variables);
+  const path = prefix ? `${prefix}/${name}` : name;
+
+  if (node.type === "folder") {
+    paths.push(path);
+    walkChildren(node.children ?? [], path, paths, variables);
+    return;
+  }
+
+  if (node.type === "file") {
+    paths.push(path);
+    return;
+  }
+};
+
+const walkChildren = (
+  children: SchemaNode[],
+  prefix: string,
+  paths: string[],
+  variables: Record<string, string>
+): void => {
+  // Track the result of the most recent `<if>` so a sibling `<else>` knows
+  // whether to emit. Any non-if/else node clears the state.
+  let lastIfWasTrue: boolean | null = null;
+
+  for (const child of children) {
+    if (child.type === "if") {
+      const truthy = isTruthy(child.condition_var, variables);
+      lastIfWasTrue = truthy;
+      if (truthy) {
+        walkChildren(child.children ?? [], prefix, paths, variables);
+      }
+      continue;
+    }
+
+    if (child.type === "else") {
+      if (lastIfWasTrue === false) {
+        walkChildren(child.children ?? [], prefix, paths, variables);
+      }
+      lastIfWasTrue = null;
+      continue;
+    }
+
+    if (child.type === "repeat") {
+      const count = parseRepeatCount(child.repeat_count, variables);
+      const iterName = child.repeat_as ?? "i";
+      for (let i = 0; i < count; i++) {
+        const scoped: Record<string, string> = {
+          ...variables,
+          [`%${iterName}%`]: String(i),
+        };
+        walkChildren(child.children ?? [], prefix, paths, scoped);
+      }
+      lastIfWasTrue = null;
+      continue;
+    }
+
+    walk(child, prefix, paths, variables);
+    lastIfWasTrue = null;
+  }
+};
+
+const isTruthy = (
+  conditionVar: string | undefined,
+  variables: Record<string, string>
+): boolean => {
+  if (!conditionVar) return false;
+  const value = variables[`%${conditionVar}%`];
+  if (value === undefined) return false;
+  const trimmed = value.trim().toLowerCase();
+  return trimmed !== "" && trimmed !== "false" && trimmed !== "0";
+};
+
+const parseRepeatCount = (
+  raw: string | undefined,
+  variables: Record<string, string>
+): number => {
+  if (!raw) return 0;
+  const substituted = substituteInName(raw, variables);
+  const n = Number.parseInt(substituted, 10);
+  if (!Number.isFinite(n) || n < 0) return 0;
+  return n;
+};

--- a/fixtures/schema-structure.json
+++ b/fixtures/schema-structure.json
@@ -1,0 +1,129 @@
+[
+  {
+    "name": "plain folder with one file and variable substitution",
+    "tree": {
+      "root": {
+        "type": "folder",
+        "name": "%NAME%",
+        "children": [
+          { "type": "file", "name": "hello.txt" }
+        ]
+      },
+      "stats": { "folders": 0, "files": 0, "downloads": 0, "generated": 0 }
+    },
+    "variables": { "%NAME%": "demo" },
+    "expectedPaths": ["demo", "demo/hello.txt"]
+  },
+  {
+    "name": "if truthy includes child",
+    "tree": {
+      "root": {
+        "type": "folder",
+        "name": "root",
+        "children": [
+          {
+            "type": "if",
+            "name": "",
+            "condition_var": "FLAG",
+            "children": [{ "type": "file", "name": "yes.txt" }]
+          }
+        ]
+      },
+      "stats": { "folders": 0, "files": 0, "downloads": 0, "generated": 0 }
+    },
+    "variables": { "%FLAG%": "on" },
+    "expectedPaths": ["root", "root/yes.txt"]
+  },
+  {
+    "name": "if falsy excludes child",
+    "tree": {
+      "root": {
+        "type": "folder",
+        "name": "root",
+        "children": [
+          {
+            "type": "if",
+            "name": "",
+            "condition_var": "FLAG",
+            "children": [{ "type": "file", "name": "yes.txt" }]
+          }
+        ]
+      },
+      "stats": { "folders": 0, "files": 0, "downloads": 0, "generated": 0 }
+    },
+    "variables": {},
+    "expectedPaths": ["root"]
+  },
+  {
+    "name": "else branch when if is falsy",
+    "tree": {
+      "root": {
+        "type": "folder",
+        "name": "root",
+        "children": [
+          {
+            "type": "if",
+            "name": "",
+            "condition_var": "FLAG",
+            "children": [{ "type": "file", "name": "yes.txt" }]
+          },
+          {
+            "type": "else",
+            "name": "",
+            "children": [{ "type": "file", "name": "no.txt" }]
+          }
+        ]
+      },
+      "stats": { "folders": 0, "files": 0, "downloads": 0, "generated": 0 }
+    },
+    "variables": {},
+    "expectedPaths": ["root", "root/no.txt"]
+  },
+  {
+    "name": "repeat with literal count emits N files",
+    "tree": {
+      "root": {
+        "type": "folder",
+        "name": "root",
+        "children": [
+          {
+            "type": "repeat",
+            "name": "",
+            "repeat_count": "3",
+            "repeat_as": "i",
+            "children": [{ "type": "file", "name": "item-%i%.txt" }]
+          }
+        ]
+      },
+      "stats": { "folders": 0, "files": 0, "downloads": 0, "generated": 0 }
+    },
+    "variables": {},
+    "expectedPaths": [
+      "root",
+      "root/item-0.txt",
+      "root/item-1.txt",
+      "root/item-2.txt"
+    ]
+  },
+  {
+    "name": "repeat with count from variable",
+    "tree": {
+      "root": {
+        "type": "folder",
+        "name": "root",
+        "children": [
+          {
+            "type": "repeat",
+            "name": "",
+            "repeat_count": "%COUNT%",
+            "repeat_as": "n",
+            "children": [{ "type": "file", "name": "x-%n%.txt" }]
+          }
+        ]
+      },
+      "stats": { "folders": 0, "files": 0, "downloads": 0, "generated": 0 }
+    },
+    "variables": { "%COUNT%": "2" },
+    "expectedPaths": ["root", "root/x-0.txt", "root/x-1.txt"]
+  }
+]


### PR DESCRIPTION
Implements #101, extending the harness from #95 to schema-structure semantics — variable substitution in names, repeat expansion, and condition (if/else) evaluation.

## What

- `fixtures/schema-structure.json` — `[{ name, tree, variables, expectedPaths }]`, the cross-target spec.
- **Rust** contract test walks the `DiffNode` tree returned by `generate_diff_preview` and collects planned relative paths (dedup the virtual nodes that wrap repeat/if blocks).
- **Web TS** contract test uses a new pure `expandTreeToPaths` in `apps/desktop/src/lib/adapters/web/expand-tree.ts` — no `FileSystemDirectoryHandle` dependency, so the contract is callable from Node/vitest. Mirrors Rust's planning semantics.

Cases cover: folder+file with `%NAME%` substitution, `<if>` truthy/falsy, `<if>`/`<else>`, `<repeat>` with literal count, `<repeat>` with count from variable.

## Notable finding

While wiring this, the contract surfaced a real divergence: web's `substituteVariables` **uppercases its lookup key**, so a lowercase iteration var (`%i%`) fails to substitute; Rust's substitution is case-preserved. `expand-tree.ts` uses a case-preserved substituter mirroring Rust. Worth following up separately as a cross-target convention bug.

## Verification

- Full desktop suite **353/353** (`tsc` clean); Rust **247/247**.

Closes #101