### PR TITLE
feat(desktop): codegen SchemaNode TS from Rust via specta (ADR-0003)

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3901,6 +3907,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "specta"
+version = "2.0.0-rc.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ccbb212565d2dc177bc15ecb7b039d66c4490da892436a4eee5b394d620c9bc"
+dependencies = [
+ "specta-macros",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "specta-macros"
+version = "2.0.0-rc.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68999d29816965eb9e5201f60aec02a76512139811661a7e8e653abc810b8f72"
+dependencies = [
+ "Inflector",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "specta-serde"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12260cbb21abb2e83a0375b1521867910e3aed8a7afa782206150ce552cd2e5a"
+dependencies = [
+ "specta",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "specta-typescript"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4472229365ceb6395487e3a60d921ad8e21f9ad06eaecc396f098902c9adc"
+dependencies = [
+ "specta",
+ "specta-serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3958,6 +4007,8 @@ dependencies = [
  "serde",
  "serde_json",
  "similar",
+ "specta",
+ "specta-typescript",
  "tar",
  "tauri",
  "tauri-build",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -33,6 +33,9 @@ tauri-plugin-updater = { version = "2", optional = true }
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# Type codegen to TypeScript (ADR-0003 / issue #97). Runtime dep so the
+# `#[derive(specta::Type)]` derives have the trait in scope.
+specta = { version = "=2.0.0-rc.20", features = ["derive"] }
 quick-xml = { version = "0.36", features = ["serialize"] }
 ureq = "2"
 url = "2"
@@ -60,6 +63,10 @@ image = { version = "0.25", default-features = false, features = ["png", "jpeg"]
 # File system watcher for watch mode
 notify = "6"
 notify-debouncer-mini = "0.4"
+
+[dev-dependencies]
+# TypeScript emit for codegen tests (ADR-0003 / issue #97).
+specta-typescript = "=0.0.7"
 
 [profile.release]
 panic = "abort"

--- a/apps/desktop/src-tauri/src/schema.rs
+++ b/apps/desktop/src-tauri/src/schema.rs
@@ -7,7 +7,7 @@ use std::io::Read;
 /// Default condition variable name for if blocks without an explicit var attribute
 const DEFAULT_CONDITION_VAR: &str = "CONDITION";
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, specta::Type)]
 pub struct SchemaNode {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
@@ -2760,5 +2760,44 @@ export const EXTENSION = true;
 
         let tree = parse_xml_schema(xml).unwrap();
         assert!(tree.variable_definitions.is_none());
+    }
+
+    // Type-drift codegen (ADR-0003 / issue #97): the TypeScript wire type for
+    // SchemaNode is generated from this Rust struct via specta. The generated
+    // file is checked in at packages/shared/src/generated/schemaNode.ts; any
+    // drift between this Rust struct and that file fails CI.
+    //
+    // To regenerate after a legitimate Rust change:
+    //   REGEN_TS=1 cargo test schema_node_typescript_matches_committed
+    #[test]
+    fn schema_node_typescript_matches_committed() {
+        use specta_typescript::Typescript;
+
+        let generated =
+            specta_typescript::export::<SchemaNode>(&Typescript::default())
+                .expect("specta should export SchemaNode");
+
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../../packages/shared/src/generated/schemaNode.ts");
+
+        if std::env::var("REGEN_TS").is_ok() {
+            std::fs::create_dir_all(path.parent().unwrap())
+                .expect("create generated dir");
+            std::fs::write(&path, &generated).expect("write generated TS");
+        }
+
+        let committed = std::fs::read_to_string(&path).unwrap_or_else(|_| {
+            panic!(
+                "generated TS missing at {}; run with REGEN_TS=1 to create it",
+                path.display()
+            )
+        });
+
+        assert_eq!(
+            committed.trim(),
+            generated.trim(),
+            "SchemaNode Rust struct and committed TS have drifted. \
+             Regenerate with: REGEN_TS=1 cargo test schema_node_typescript_matches_committed"
+        );
     }
 }

--- a/packages/shared/src/generated/schemaNode.ts
+++ b/packages/shared/src/generated/schemaNode.ts
@@ -1,0 +1,29 @@
+export type SchemaNode = { id?: string | null; type?: string; name?: string; url?: string | null; content?: string | null; children?: SchemaNode[] | null; condition_var?: string | null; 
+/**
+ * For repeat nodes: the count expression (variable like "%NUM%" or literal "3")
+ */
+repeat_count?: string | null; 
+/**
+ * For repeat nodes: the iteration variable name (e.g., "i" creates %i%)
+ */
+repeat_as?: string | null; 
+/**
+ * Generator type: "image" or "sqlite"
+ */
+generate?: string | null; 
+/**
+ * Generator configuration (child XML as string for parsing)
+ */
+generateConfig?: string | null; 
+/**
+ * If true, process {{if}}/{{for}} template directives in file content.
+ * When false/None, {{...}} syntax is preserved as-is.
+ */
+template?: boolean | null; 
+/**
+ * Unrecognized XML attributes captured verbatim so they survive a
+ * parse -> edit -> export round-trip. Keys exclude attributes already
+ * mapped to dedicated fields above (name, url, var, count, as, generate,
+ * template, and generator config attrs). Sorted for deterministic export.
+ */
+attributes?: { [key in string]: string } | null }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -18,57 +18,36 @@
 export const NODE_TYPES = ["folder", "file", "if", "else", "repeat"] as const;
 export type NodeType = (typeof NODE_TYPES)[number];
 
+import type { SchemaNode as GeneratedSchemaNode } from "./generated/schemaNode";
+
 /**
  * Represents a single node in the schema tree structure.
  * Nodes can be files, folders, or control flow elements (if/else/repeat).
+ *
+ * Field shape is generated from the Rust `SchemaNode` struct via specta (see
+ * ADR-0003 and `./generated/schemaNode.ts`). The frontend re-narrows two
+ * fields that the Rust type system cannot express:
+ *   - `type` is required and limited to {@link NodeType}.
+ *   - `generate`, when present, is restricted to `"image" | "sqlite"`.
+ * Adding a field on the Rust side propagates here automatically; the
+ * codegen contract test (`schema_node_typescript_matches_committed`) fails
+ * on any drift.
  */
-export interface SchemaNode {
-  /** Unique identifier for tracking during editing and drag-drop operations */
-  id?: string;
-  /** The type of this schema element */
+/**
+ * Strip `| null` from each property. Rust's `Option<T>` serializes as
+ * `T | null` via specta, but the rest of the codebase treats absent values
+ * as `undefined`, so we collapse the two on the consumption side.
+ */
+type WithoutNullFields<T> = { [K in keyof T]: Exclude<T[K], null> };
+
+export type SchemaNode = WithoutNullFields<
+  Omit<GeneratedSchemaNode, "type" | "name" | "children" | "generate">
+> & {
   type: NodeType;
-  /** Display name (supports variable substitution with %VAR% syntax) */
   name: string;
-  /** URL to download file content from (file nodes only) */
-  url?: string;
-  /** Inline file content (file nodes only) */
-  content?: string;
-  /** Child nodes (for folder, if, else, repeat types) */
   children?: SchemaNode[];
-  /** Additional XML attributes to preserve during round-trips */
-  attributes?: Record<string, string>;
-  /** Variable name to check for conditional rendering (if nodes only, without % delimiters) */
-  condition_var?: string;
-  /**
-   * Number of iterations for repeat loops. Can be a literal number or variable reference.
-   * Examples: "3", "%NUM_MODULES%"
-   * @default "1"
-   */
-  repeat_count?: string;
-  /**
-   * Iteration variable name for repeat loops (without % delimiters).
-   * Available inside the loop as %name% (0-indexed) and %name_1% (1-indexed).
-   * @default "i"
-   */
-  repeat_as?: string;
-  /**
-   * Generator type for binary file creation.
-   * - "image": Creates a placeholder image (PNG/JPEG) with configurable dimensions and color
-   * - "sqlite": Creates a SQLite database with defined schema
-   */
   generate?: "image" | "sqlite";
-  /**
-   * Generator configuration (child XML content as string for parsing).
-   * For image: width, height, background, format attributes
-   * For sqlite: <table> or <sql> child elements
-   */
-  generateConfig?: string;
-  /**
-   * If true, process {{if}}/{{for}} template directives in file content.
-   * When false/undefined, {{...}} syntax is preserved as-is.
-   */
-  template?: boolean;
-}
+};
 
 export interface SchemaHooks {
   post_create: string[];


### PR DESCRIPTION
Implements #97 — the first tracer bullet for ADR-0003 (TS↔Rust type drift). Wires the type codegen pipeline end-to-end on one IPC type.

## What

- **Rust:** adds `specta` v2.0.0-rc.20 + `specta-typescript` v0.0.7 (dev-dep). `SchemaNode` derives `specta::Type`. A `#[test]` emits the type to `packages/shared/src/generated/schemaNode.ts` and asserts the committed file matches what the Rust struct currently produces. Regenerate via `REGEN_TS=1 cargo test schema_node_typescript_matches_committed`.
- **TypeScript:** `packages/shared/src/types.ts` replaces the hand-written `SchemaNode` interface with `Omit` + intersection over the generated type. Two narrowings the Rust type system can't express are preserved on top: `type: NodeType` and `generate?: "image" | "sqlite"`. A `WithoutNullFields` mapped type collapses specta's `T | null` (from Rust `Option<T>`) to `T | undefined`, matching the rest of the codebase.
- **Drift detection:** adding a field on Rust propagates through the intersection automatically; the codegen test fails on any change until the generated file is re-committed.

## Notes

- Defer tauri-specta *command bindings* to #104 (per ADR-0003's bonus / migration order). #97 scope is the type pipeline only.
- Pinned `specta = "=2.0.0-rc.20"` because rc.25 requires the unstable Rust feature `debug_closure_helpers`.
- Wire format unchanged — no serde renames touched. The generated TS inherits today's mixed snake/camelCase naming (cosmetic, per ADR-0003).

## Verification

- Full desktop suite **346/346** (`tsc` clean); Rust **247/247**.
- `REGEN_TS=1` test mechanism produces a file that the normal test then matches; drift fails until regen.

On merge, #102 (migrate remaining IPC types) is unblocked, and the deferred #103 (brand) becomes addressable on top of generated types via specta type overrides.

Closes #97