### PR TITLE
feat: extend codegen to template + validation cluster (#114 partial)

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -3912,6 +3912,7 @@ version = "2.0.0-rc.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ccbb212565d2dc177bc15ecb7b039d66c4490da892436a4eee5b394d620c9bc"
 dependencies = [
+ "serde_json",
  "specta-macros",
  "thiserror 1.0.69",
 ]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -35,7 +35,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # Type codegen to TypeScript (ADR-0003 / issue #97). Runtime dep so the
 # `#[derive(specta::Type)]` derives have the trait in scope.
-specta = { version = "=2.0.0-rc.20", features = ["derive"] }
+specta = { version = "=2.0.0-rc.20", features = ["derive", "serde_json"] }
 quick-xml = { version = "0.36", features = ["serialize"] }
 ureq = "2"
 url = "2"

--- a/apps/desktop/src-tauri/src/database.rs
+++ b/apps/desktop/src-tauri/src/database.rs
@@ -59,7 +59,7 @@ fn validate_tags(tags: &[String]) -> Vec<String> {
 }
 
 /// Validation rule for a variable
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, specta::Type)]
 pub struct ValidationRule {
     pub pattern: Option<String>,
     pub min_length: Option<usize>,
@@ -72,7 +72,7 @@ pub struct ValidationRule {
 const MAX_RECENT_PROJECTS: usize = 20;
 
 /// A recent project entry
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
 pub struct RecentProject {
     pub id: String,
     pub project_name: String,
@@ -142,7 +142,7 @@ fn row_to_recent_project(row: &rusqlite::Row) -> rusqlite::Result<RecentProject>
     })
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
 pub struct Template {
     pub id: String,
     pub name: String,
@@ -254,7 +254,7 @@ pub struct UpdateTemplateInput {
 // ============================================================================
 
 /// A configured team library (shared folder containing .sct template files)
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
 pub struct TeamLibrary {
     pub id: String,
     pub name: String,
@@ -289,7 +289,7 @@ pub struct UpdateTeamLibraryInput {
 }
 
 /// A sync log entry for audit trail
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
 pub struct SyncLogEntry {
     pub id: String,
     pub library_id: String,
@@ -330,7 +330,7 @@ fn row_to_sync_log_entry(row: &rusqlite::Row) -> rusqlite::Result<SyncLogEntry> 
 // ============================================================================
 
 /// Plugin capability types
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, specta::Type)]
 #[serde(rename_all = "kebab-case")]
 pub enum PluginCapability {
     FileProcessor,
@@ -340,7 +340,7 @@ pub enum PluginCapability {
 }
 
 /// A registered plugin
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
 pub struct Plugin {
     pub id: String,
     pub name: String,

--- a/apps/desktop/src-tauri/src/plugins.rs
+++ b/apps/desktop/src-tauri/src/plugins.rs
@@ -17,7 +17,7 @@ use std::path::PathBuf;
 use crate::database::{CreatePluginInput, PluginCapability};
 
 /// Plugin manifest structure (plugin.json)
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
 pub struct PluginManifest {
     /// Unique plugin name (used as directory name)
     pub name: String,

--- a/apps/desktop/src-tauri/src/schema.rs
+++ b/apps/desktop/src-tauri/src/schema.rs
@@ -981,7 +981,7 @@ pub struct TemplateData {
 }
 
 /// Result of parsing a schema with inheritance resolved
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
 #[serde(rename_all = "camelCase")]
 pub struct ParseWithInheritanceResult {
     pub tree: SchemaTree,
@@ -2781,7 +2781,16 @@ export const EXTENSION = true;
         // Each entry is a single IPC-crossing type whose generated TS form
         // is bundled into packages/shared/src/generated/types.ts. Adding a
         // type here is the migration step for ADR-0003 / issue #102.
-        let mut bundled = String::new();
+        //
+        // Prepend a JsonValue alias because specta's serde_json feature emits
+        // unrestricted `JsonValue` references for `serde_json::Value` fields
+        // (e.g. Template.wizard_config). The frontend re-narrows those fields
+        // to typed values in `packages/shared/src/types.ts`.
+        let mut bundled = String::from(
+            "// Auto-generated from Rust via specta. Do not edit by hand.\n\
+             // Regenerate with: REGEN_TS=1 cargo test ipc_types_match_committed_typescript\n\
+             export type JsonValue = unknown;\n",
+        );
 
         macro_rules! emit {
             ($t:ty) => {
@@ -2820,6 +2829,33 @@ export const EXTENSION = true;
         emit!(crate::types::DiffNode);
         emit!(crate::types::DiffSummary);
         emit!(crate::types::DiffResult);
+
+        // Template + import/export (#114 phase 2)
+        emit!(crate::types::ExportFileType);
+        emit!(crate::types::TemplateExportFile);
+        emit!(crate::types::TemplateExport);
+        emit!(crate::types::ImportResult);
+        emit!(crate::database::Template);
+
+        // Recent projects
+        emit!(crate::database::RecentProject);
+
+        // Team library
+        emit!(crate::database::SyncLogEntry);
+        emit!(crate::database::TeamLibrary);
+        emit!(crate::team_library::TeamTemplate);
+
+        // Plugins
+        emit!(crate::database::PluginCapability);
+        emit!(crate::database::Plugin);
+        emit!(crate::plugins::PluginManifest);
+
+        // Validation + inheritance
+        emit!(crate::validation::ValidationSeverity);
+        emit!(crate::validation::ValidationIssueType);
+        emit!(crate::validation::ValidationIssue);
+        emit!(crate::validation::SchemaValidationResult);
+        emit!(ParseWithInheritanceResult);
 
         let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("../../../packages/shared/src/generated/types.ts");

--- a/apps/desktop/src-tauri/src/team_library.rs
+++ b/apps/desktop/src-tauri/src/team_library.rs
@@ -14,7 +14,7 @@ use crate::database::{CreateTemplateInput, Database, ValidationRule};
 const TEMPLATE_EXTENSION: &str = "sct";
 
 /// Represents a template found in a team library folder
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
 pub struct TeamTemplate {
     /// Template name (derived from filename or export metadata)
     pub name: String,

--- a/apps/desktop/src-tauri/src/types.rs
+++ b/apps/desktop/src-tauri/src/types.rs
@@ -211,7 +211,7 @@ pub struct DiffResult {
 // Template Export/Import Types
 // ============================================================================
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
 pub struct TemplateExport {
     pub name: String,
     pub description: Option<String>,
@@ -231,7 +231,7 @@ pub struct TemplateExport {
 }
 
 /// Type of export file - single template or bundle
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
 #[serde(rename_all = "snake_case")]
 pub enum ExportFileType {
     /// Single template export
@@ -240,7 +240,7 @@ pub enum ExportFileType {
     TemplateBundle,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
 pub struct TemplateExportFile {
     pub version: String,
     #[serde(rename = "type")]
@@ -252,7 +252,7 @@ pub struct TemplateExportFile {
     pub templates: Option<Vec<TemplateExport>>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
 pub struct ImportResult {
     pub imported: Vec<String>,
     pub skipped: Vec<String>,

--- a/apps/desktop/src-tauri/src/validation.rs
+++ b/apps/desktop/src-tauri/src/validation.rs
@@ -21,7 +21,7 @@ use crate::schema::{parse_xml_schema, resolve_template_inheritance, SchemaNode, 
 use crate::transforms::find_variable_refs;
 
 /// Severity level for validation issues
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, specta::Type)]
 #[serde(rename_all = "snake_case")]
 pub enum ValidationSeverity {
     Error,
@@ -29,7 +29,7 @@ pub enum ValidationSeverity {
 }
 
 /// Type of validation issue
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, specta::Type)]
 #[serde(rename_all = "snake_case")]
 pub enum ValidationIssueType {
     XmlSyntax,
@@ -41,7 +41,7 @@ pub enum ValidationIssueType {
 }
 
 /// A single validation issue found in the schema
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
 #[serde(rename_all = "camelCase")]
 pub struct ValidationIssue {
     pub severity: ValidationSeverity,
@@ -56,7 +56,7 @@ pub struct ValidationIssue {
 }
 
 /// Result of schema validation
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
 #[serde(rename_all = "camelCase")]
 pub struct SchemaValidationResult {
     /// True if no errors were found (warnings don't affect this)

--- a/packages/shared/src/generated/types.ts
+++ b/packages/shared/src/generated/types.ts
@@ -1,3 +1,6 @@
+// Auto-generated from Rust via specta. Do not edit by hand.
+// Regenerate with: REGEN_TS=1 cargo test ipc_types_match_committed_typescript
+export type JsonValue = unknown;
 export type SchemaNode = { id?: string | null; type?: string; name?: string; url?: string | null; content?: string | null; children?: SchemaNode[] | null; condition_var?: string | null; 
 /**
  * For repeat nodes: the count expression (variable like "%NUM%" or literal "3")
@@ -214,3 +217,155 @@ warnings: string[] }
  * Complete diff preview result
  */
 export type DiffResult = { root: DiffNode; summary: DiffSummary }
+/**
+ * Type of export file - single template or bundle
+ */
+export type ExportFileType = 
+/**
+ * Single template export
+ */
+"template" | 
+/**
+ * Multiple templates bundled together
+ */
+"template_bundle"
+export type TemplateExportFile = { version: string; type: ExportFileType; exported_at: string; template?: TemplateExport | null; templates?: TemplateExport[] | null }
+export type TemplateExport = { name: string; description: string | null; schema_xml: string; variables?: { [key in string]: string } | null; 
+/**
+ * Validation rules for variables (optional, for backwards compatibility)
+ */
+variable_validation: { [key in string]: ValidationRule }; icon_color: string | null; 
+/**
+ * Tags for categorizing templates (optional, for backwards compatibility)
+ */
+tags: string[]; 
+/**
+ * Wizard configuration for guided template setup (optional)
+ */
+wizard_config?: JsonValue | null }
+export type ImportResult = { imported: string[]; skipped: string[]; errors: string[] }
+export type Template = { id: string; name: string; description: string | null; schema_xml: string; variables: { [key in string]: string }; variable_validation?: { [key in string]: ValidationRule }; icon_color: string | null; is_favorite: boolean; use_count: number; created_at: string; updated_at: string; tags?: string[]; 
+/**
+ * Wizard configuration for guided template setup (JSON)
+ */
+wizard_config: JsonValue | null }
+/**
+ * A recent project entry
+ */
+export type RecentProject = { id: string; project_name: string; output_path: string; schema_xml: string; variables: { [key in string]: string }; variable_validation?: { [key in string]: ValidationRule }; template_id: string | null; template_name: string | null; folders_created: number; files_created: number; created_at: string }
+/**
+ * A sync log entry for audit trail
+ */
+export type SyncLogEntry = { id: string; library_id: string; action: string; template_name: string | null; details: string | null; created_at: string }
+/**
+ * A configured team library (shared folder containing .sct template files)
+ */
+export type TeamLibrary = { id: string; name: string; path: string; sync_interval: number; last_sync_at: string | null; is_enabled: boolean; created_at: string; updated_at: string }
+/**
+ * Represents a template found in a team library folder
+ */
+export type TeamTemplate = { 
+/**
+ * Template name (derived from filename or export metadata)
+ */
+name: string; 
+/**
+ * Description from the template export file
+ */
+description: string | null; 
+/**
+ * Full path to the .sct file
+ */
+file_path: string; 
+/**
+ * File modification time (ISO 8601)
+ */
+modified_at: string; 
+/**
+ * File size in bytes
+ */
+size_bytes: number }
+/**
+ * Plugin capability types
+ */
+export type PluginCapability = "file-processor" | "variable-transformer" | "schema-validator" | "post-create-hook"
+/**
+ * A registered plugin
+ */
+export type Plugin = { id: string; name: string; version: string; description: string | null; path: string; capabilities: PluginCapability[]; file_types: string[]; user_settings: JsonValue; is_enabled: boolean; load_order: number; installed_at: string; updated_at: string }
+/**
+ * Plugin manifest structure (plugin.json)
+ */
+export type PluginManifest = { 
+/**
+ * Unique plugin name (used as directory name)
+ */
+name: string; 
+/**
+ * Semantic version (e.g., "1.0.0")
+ */
+version: string; 
+/**
+ * Human-readable description
+ */
+description?: string | null; 
+/**
+ * Plugin capabilities (what hooks it provides)
+ */
+capabilities?: string[]; 
+/**
+ * File extensions this plugin processes (for file-processor capability)
+ */
+fileTypes?: string[]; 
+/**
+ * Main entry point (default: "index.js")
+ */
+main?: string; 
+/**
+ * Plugin author
+ */
+author?: string | null; 
+/**
+ * Plugin license
+ */
+license?: string | null }
+/**
+ * Severity level for validation issues
+ */
+export type ValidationSeverity = "error" | "warning"
+/**
+ * Type of validation issue
+ */
+export type ValidationIssueType = "xml_syntax" | "undefined_variable" | "duplicate_name" | "circular_inheritance" | "inheritance_error" | "invalid_url"
+/**
+ * A single validation issue found in the schema
+ */
+export type ValidationIssue = { severity: ValidationSeverity; issueType: ValidationIssueType; message: string; 
+/**
+ * Path to the node where the issue was found (e.g., "root/src/components")
+ */
+nodePath?: string | null; 
+/**
+ * The problematic value (e.g., the undefined variable name or invalid URL)
+ */
+value?: string | null }
+/**
+ * Result of schema validation
+ */
+export type SchemaValidationResult = { 
+/**
+ * True if no errors were found (warnings don't affect this)
+ */
+isValid: boolean; 
+/**
+ * Error-level issues that block creation
+ */
+errors: ValidationIssue[]; 
+/**
+ * Warning-level issues that are advisory
+ */
+warnings: ValidationIssue[] }
+/**
+ * Result of parsing a schema with inheritance resolved
+ */
+export type ParseWithInheritanceResult = { tree: SchemaTree; mergedVariables: { [key in string]: string }; mergedVariableValidation: { [key in string]: ValidationRule }; baseTemplates: string[] }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -45,12 +45,31 @@ import type {
   DiffNode as GeneratedDiffNode,
   DiffSummary as GeneratedDiffSummary,
   DiffResult as GeneratedDiffResult,
+  // Phase 2 (#114): types whose hand-written naming already matches the wire.
+  // RecentProject, TeamLibrary, TeamTemplate, SyncLogEntry, Plugin,
+  // PluginManifest are NOT swapped in because the Tauri adapter manually
+  // translates snake_case wire fields to camelCase frontend fields; migrating
+  // those means also removing the translation layer (separate work).
+  Template as GeneratedTemplate,
+  TemplateExport as GeneratedTemplateExport,
+  TemplateExportFile as GeneratedTemplateExportFile,
+  ExportFileType as GeneratedExportFileType,
+  ImportResult as GeneratedImportResult,
+  PluginCapability as GeneratedPluginCapability,
+  ValidationSeverity as GeneratedValidationSeverity,
+  ValidationIssueType as GeneratedValidationIssueType,
+  ValidationIssue as GeneratedValidationIssue,
+  SchemaValidationResult as GeneratedSchemaValidationResult,
+  ParseWithInheritanceResult as GeneratedParseWithInheritanceResult,
 } from "./generated/types";
 
 /**
  * Strip `| null` from each property. Rust's `Option<T>` serializes as
  * `T | null` via specta, but the rest of the codebase treats absent values
- * as `undefined`, so we collapse the two on the consumption side.
+ * as `undefined`, so we collapse the two on the consumption side. For
+ * required-nullable fields where call sites legitimately pass `null` (e.g.
+ * `Template.description`), the per-type narrowing keeps the field nullable
+ * via an explicit `Omit` + re-add.
  */
 type WithoutNullFields<T> = { [K in keyof T]: Exclude<T[K], null> };
 
@@ -273,46 +292,40 @@ export type WizardAnswers = Record<string, string | boolean | string[]>;
 // Template Types
 // ============================================================================
 
-export interface Template {
-  id: string;
-  name: string;
-  description: string | null;
-  schema_xml: string;
-  variables: Record<string, string>;
-  variable_validation?: Record<string, ValidationRule>;
-  icon_color: string | null;
-  is_favorite: boolean;
-  use_count: number;
-  created_at: string;
-  updated_at: string;
-  tags: string[];
+/**
+ * Template record. The Rust struct stores `wizard_config` as
+ * `serde_json::Value`, so it appears as `JsonValue` in the generated TS; the
+ * frontend re-narrows it to the typed {@link WizardConfig}.
+ */
+export type Template = Omit<
+  GeneratedTemplate,
+  "wizard_config" | "variable_validation" | "tags"
+> & {
   wizard_config: WizardConfig | null;
-}
-
-export interface TemplateExport {
-  name: string;
-  description: string | null;
-  schema_xml: string;
-  variables?: Record<string, string>;
   variable_validation?: Record<string, ValidationRule>;
-  icon_color: string | null;
-  tags?: string[];
-  wizard_config?: WizardConfig | null;
-}
+  tags: string[];
+};
 
-export interface TemplateExportFile {
-  version: string;
-  type: "template" | "template_bundle";
-  exported_at: string;
+export type TemplateExport = Omit<
+  GeneratedTemplateExport,
+  "wizard_config" | "variable_validation" | "tags"
+> & {
+  wizard_config?: WizardConfig | null;
+  variable_validation?: Record<string, ValidationRule>;
+  tags?: string[];
+};
+
+export type ExportFileType = GeneratedExportFileType;
+
+export type TemplateExportFile = Omit<
+  WithoutNullFields<GeneratedTemplateExportFile>,
+  "template" | "templates"
+> & {
   template?: TemplateExport;
   templates?: TemplateExport[];
-}
+};
 
-export interface ImportResult {
-  imported: string[];
-  skipped: string[];
-  errors: string[];
-}
+export type ImportResult = WithoutNullFields<GeneratedImportResult>;
 
 export type DuplicateStrategy = "skip" | "replace" | "rename";
 
@@ -381,67 +394,34 @@ export const ACCENT_COLORS: Record<AccentColor, string> = {
  * Result of parsing a schema with template inheritance resolved.
  * Returned by cmd_parse_schema_with_inheritance.
  */
-export interface ParseWithInheritanceResult {
+export type ParseWithInheritanceResult = Omit<
+  WithoutNullFields<GeneratedParseWithInheritanceResult>,
+  "tree" | "mergedVariableValidation"
+> & {
   /** The fully resolved schema tree with inherited content merged */
   tree: SchemaTree;
-  /** Variables merged from all base templates (child values override base) */
-  mergedVariables: Record<string, string>;
-  /** Validation rules merged from all base templates (child rules override base) */
   mergedVariableValidation: Record<string, ValidationRule>;
-  /** List of base template names that were extended (in resolution order) */
-  baseTemplates: string[];
-}
+};
 
 // ============================================================================
 // Schema Validation Types
 // ============================================================================
 
-/**
- * Severity level for validation issues.
- * - error: Blocks structure creation
- * - warning: Advisory only, doesn't block creation
- */
-export type ValidationSeverity = "error" | "warning";
-
-/**
- * Type of validation issue found in the schema.
- */
-export type ValidationIssueType =
-  | "xml_syntax"
-  | "undefined_variable"
-  | "duplicate_name"
-  | "circular_inheritance"
-  | "inheritance_error"
-  | "invalid_url";
-
-/**
- * A single validation issue found during schema validation.
- */
-export interface ValidationIssue {
-  /** Severity level of the issue */
-  severity: ValidationSeverity;
-  /** Type of validation issue */
-  issueType: ValidationIssueType;
-  /** Human-readable description of the issue */
-  message: string;
-  /** Path to the node where the issue was found (e.g., "root/src/components") */
-  nodePath?: string;
-  /** The problematic value (e.g., the undefined variable name or invalid URL) */
-  value?: string;
-}
+export type ValidationSeverity = GeneratedValidationSeverity;
+export type ValidationIssueType = GeneratedValidationIssueType;
+export type ValidationIssue = WithoutNullFields<GeneratedValidationIssue>;
 
 /**
  * Result of schema validation.
  * Returned by cmd_validate_schema.
  */
-export interface SchemaValidationResult {
-  /** True if no errors were found (warnings don't affect this) */
-  isValid: boolean;
-  /** Error-level issues that block creation */
+export type SchemaValidationResult = Omit<
+  WithoutNullFields<GeneratedSchemaValidationResult>,
+  "errors" | "warnings"
+> & {
   errors: ValidationIssue[];
-  /** Warning-level issues that are advisory */
   warnings: ValidationIssue[];
-}
+};
 
 // ============================================================================
 // Team Library Types
@@ -525,11 +505,7 @@ export interface TeamImportResult {
 /**
  * Plugin capabilities define what hooks a plugin provides.
  */
-export type PluginCapability =
-  | "file-processor"
-  | "variable-transformer"
-  | "schema-validator"
-  | "post-create-hook";
+export type PluginCapability = GeneratedPluginCapability;
 
 /**
  * A registered plugin in the system.


### PR DESCRIPTION
Continues #102 / ADR-0003 by extending the codegen bundle from 22 to 40 IPC types and migrating 11 of the newly-generated types to narrowed re-exports.

## What

- **Rust derives** added to 15 more structs/enums across `database.rs`, `types.rs`, `team_library.rs`, `plugins.rs`, `schema.rs`, `validation.rs`. The bundled emit in `schema.rs::ipc_types_match_committed_typescript` covers them; `REGEN_TS=1 cargo test ipc_types_match_committed_typescript` regenerates.
- **specta `serde_json` feature** enabled to handle `serde_json::Value` fields (`Template.wizard_config`, `TemplateExport.wizard_config`, `Plugin.user_settings`). The bundle prepends `export type JsonValue = unknown;` so generated references resolve.
- **Shared narrowings** swap hand-written for generated-with-Omit on: `Template`, `TemplateExport`, `TemplateExportFile`, `ExportFileType`, `ImportResult`, `PluginCapability`, `ValidationSeverity`, `ValidationIssueType`, `ValidationIssue`, `SchemaValidationResult`, `ParseWithInheritanceResult`. Each preserves frontend-side narrowings (`wizard_config: WizardConfig | null`, `tree: SchemaTree`, narrowed `Record<string, ValidationRule>` for nested validation, etc.).

## Deferred — translation-layer types

The Tauri adapter currently translates 6 types between snake_case wire and camelCase frontend via manual `to*` mappers (`tauri/index.ts:77` and `plugin.ts:27` etc.): **RecentProject, TeamLibrary, TeamTemplate, SyncLogEntry, Plugin, PluginManifest**. Their derives are in place and they're emitted into the generated bundle (drift detection works), but they keep their hand-written shared types until the translation layer is removed — a separate concern. Will file a follow-up issue.

## Verification

- Full TS suite **368/368** (`tsc --noEmit` clean).
- Full Rust suite **250/250**.
- Drift test idempotent (rerun green after regen).
- No wire-format change (no serde renames touched).

Refs #114 (partial — translation-layer types follow up separately).