### PR TITLE
feat: remove snake↔camel adapter translation, complete codegen migration (#116)

### DIFF
--- a/apps/desktop/src/components/PluginManager.tsx
+++ b/apps/desktop/src/components/PluginManager.tsx
@@ -77,7 +77,7 @@ export const PluginManager = ({ isOpen, onClose }: PluginManagerProps) => {
     try {
       setError(null);
 
-      const updated = plugin.isEnabled
+      const updated = plugin.is_enabled
         ? await api.plugin.disablePlugin(plugin.id)
         : await api.plugin.enablePlugin(plugin.id);
 
@@ -121,7 +121,7 @@ export const PluginManager = ({ isOpen, onClose }: PluginManagerProps) => {
 
   if (!isOpen) return null;
 
-  const enabledCount = plugins.filter((p) => p.isEnabled).length;
+  const enabledCount = plugins.filter((p) => p.is_enabled).length;
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
@@ -247,7 +247,7 @@ const PluginCard = ({ plugin, onToggle, onUninstall, isUninstalling }: PluginCar
   return (
     <div
       className={`p-4 rounded-mac border ${
-        plugin.isEnabled
+        plugin.is_enabled
           ? "bg-card-bg border-border-muted"
           : "bg-mac-bg-hover/50 border-border-muted/50"
       }`}
@@ -257,7 +257,7 @@ const PluginCard = ({ plugin, onToggle, onUninstall, isUninstalling }: PluginCar
           <div className="flex items-center gap-2">
             <h3
               className={`text-mac-sm font-medium truncate ${
-                plugin.isEnabled ? "text-text-primary" : "text-text-muted"
+                plugin.is_enabled ? "text-text-primary" : "text-text-muted"
               }`}
             >
               {plugin.name}
@@ -280,9 +280,9 @@ const PluginCard = ({ plugin, onToggle, onUninstall, isUninstalling }: PluginCar
                 {capabilityLabels[cap] || cap}
               </span>
             ))}
-            {plugin.fileTypes.length > 0 && (
+            {plugin.file_types.length > 0 && (
               <span className="px-2 py-0.5 text-mac-xs bg-text-muted/10 text-text-muted rounded-full">
-                {plugin.fileTypes.join(", ")}
+                {plugin.file_types.join(", ")}
               </span>
             )}
           </div>
@@ -293,16 +293,16 @@ const PluginCard = ({ plugin, onToggle, onUninstall, isUninstalling }: PluginCar
           <button
             onClick={() => onToggle(plugin)}
             className={`relative w-11 h-6 rounded-full transition-colors ${
-              plugin.isEnabled ? "bg-accent" : "bg-text-muted/30"
+              plugin.is_enabled ? "bg-accent" : "bg-text-muted/30"
             }`}
-            title={plugin.isEnabled ? "Disable plugin" : "Enable plugin"}
+            title={plugin.is_enabled ? "Disable plugin" : "Enable plugin"}
           >
             <span
               className={`absolute top-1 w-4 h-4 bg-white rounded-full shadow transition-transform ${
-                plugin.isEnabled ? "left-6" : "left-1"
+                plugin.is_enabled ? "left-6" : "left-1"
               }`}
             >
-              {plugin.isEnabled && (
+              {plugin.is_enabled && (
                 <CheckIcon size={10} className="text-accent m-0.5" />
               )}
             </span>

--- a/apps/desktop/src/components/RecentProjectsSection.tsx
+++ b/apps/desktop/src/components/RecentProjectsSection.tsx
@@ -53,32 +53,32 @@ export const RecentProjectsSection = () => {
   const handleLoad = useCallback(async (project: RecentProject) => {
     try {
       // Parse the schema first (this can fail)
-      const tree = await api.schema.parseSchema(project.schemaXml);
+      const tree = await api.schema.parseSchema(project.schema_xml);
 
       // Only set state after successful parse
-      setSchemaPath(`recent:${project.projectName}`);
-      setSchemaContent(project.schemaXml);
+      setSchemaPath(`recent:${project.project_name}`);
+      setSchemaContent(project.schema_xml);
       setSchemaTree(tree);
-      setOutputPath(project.outputPath);
-      setProjectName(project.projectName);
+      setOutputPath(project.output_path);
+      setProjectName(project.project_name);
 
       // Always set variables (clears previous if project has none)
       const loadedVariables = Object.entries(project.variables).map(([name, value]) => ({
         name,
         value,
-        validation: project.variableValidation?.[name],
+        validation: project.variable_validation?.[name],
       }));
       setVariables(loadedVariables);
 
       addLog({
         type: "info",
-        message: `Loaded recent project: ${project.projectName}`,
+        message: `Loaded recent project: ${project.project_name}`,
       });
     } catch (e) {
       const errorMessage = e instanceof Error ? e.message : String(e);
       addLog({
         type: "error",
-        message: `Failed to load project "${project.projectName}"`,
+        message: `Failed to load project "${project.project_name}"`,
         details: errorMessage,
       });
     }
@@ -211,7 +211,7 @@ export const RecentProjectsSection = () => {
                     <UploadIcon size={12} />
                   </button>
                   <button
-                    onClick={(e) => handleDelete(e, project.id, project.projectName)}
+                    onClick={(e) => handleDelete(e, project.id, project.project_name)}
                     disabled={deletingId === project.id}
                     className="w-6 h-6 flex items-center justify-center rounded text-text-muted hover:text-system-red hover:bg-system-red/10 transition-colors disabled:opacity-50"
                     title="Delete from history"
@@ -228,25 +228,25 @@ export const RecentProjectsSection = () => {
                   <div className="flex-1 min-w-0">
                     {/* pr-16 to avoid overlap with 2 action buttons */}
                     <div className="text-mac-sm font-medium text-text-primary truncate pr-16">
-                      {project.projectName}
+                      {project.project_name}
                     </div>
-                    <div className="text-mac-xs text-text-muted truncate" title={project.outputPath}>
-                      {project.outputPath}
+                    <div className="text-mac-xs text-text-muted truncate" title={project.output_path}>
+                      {project.output_path}
                     </div>
                   </div>
                 </div>
                 <div className="flex items-center justify-between mt-1.5 text-mac-xs text-text-muted">
                   <div className="flex items-center gap-2">
-                    {project.templateName && (
+                    {project.template_name && (
                       <span className="px-1.5 py-0.5 bg-accent/10 text-accent rounded text-[10px]">
-                        {project.templateName}
+                        {project.template_name}
                       </span>
                     )}
-                    <span>{project.foldersCreated} dirs, {project.filesCreated} files</span>
+                    <span>{project.folders_created} dirs, {project.files_created} files</span>
                   </div>
                   <span className="flex items-center gap-0.5">
                     <ClockIcon size={10} />
-                    {formatRelativeTime(project.createdAt)}
+                    {formatRelativeTime(project.created_at)}
                   </span>
                 </div>
               </div>

--- a/apps/desktop/src/components/RightPanel.tsx
+++ b/apps/desktop/src/components/RightPanel.tsx
@@ -273,7 +273,7 @@ export const RightPanel = () => {
 
       // Load and process plugins for file-processor capability
       const enabledFileProcessors = plugins.filter(
-        (p) => p.isEnabled && p.capabilities.includes("file-processor")
+        (p) => p.is_enabled && p.capabilities.includes("file-processor")
       );
 
       let treeToCreate = effectiveTree;

--- a/apps/desktop/src/components/SettingsModal.tsx
+++ b/apps/desktop/src/components/SettingsModal.tsx
@@ -30,7 +30,7 @@ export const SettingsModal = ({ isOpen, onClose }: SettingsModalProps) => {
   const { settings, updateSetting, plugins } = useAppStore();
   const [showPluginManager, setShowPluginManager] = useState(false);
 
-  const enabledPluginCount = plugins.filter((p) => p.isEnabled).length;
+  const enabledPluginCount = plugins.filter((p) => p.is_enabled).length;
 
   const saveSetting = async (key: keyof Settings, value: string | null) => {
     try {

--- a/apps/desktop/src/components/TeamTemplateList.tsx
+++ b/apps/desktop/src/components/TeamTemplateList.tsx
@@ -54,7 +54,7 @@ const TeamTemplateItem = ({
           {template.name}
         </div>
         <div className="text-[10px] text-text-muted truncate">
-          {formatSize(template.sizeBytes)} &middot; {formatDate(template.modifiedAt)}
+          {formatSize(template.size_bytes)} &middot; {formatDate(template.modified_at)}
         </div>
       </div>
       <button
@@ -105,18 +105,18 @@ export const TeamTemplateList = () => {
   const handleImport = useCallback(async (template: TeamTemplate) => {
     if (!activeTeamLibrary) return;
 
-    setImportingTemplates((prev) => new Set(prev).add(template.filePath));
-    setImportStatuses((prev) => ({ ...prev, [template.filePath]: "idle" }));
+    setImportingTemplates((prev) => new Set(prev).add(template.file_path));
+    setImportStatuses((prev) => ({ ...prev, [template.file_path]: "idle" }));
 
     try {
       const result = await api.teamLibrary.importTeamTemplate(
         activeTeamLibrary,
-        template.filePath,
+        template.file_path,
         duplicateStrategy
       );
 
       if (result.imported.length > 0) {
-        setImportStatuses((prev) => ({ ...prev, [template.filePath]: "success" }));
+        setImportStatuses((prev) => ({ ...prev, [template.file_path]: "success" }));
         addLog({
           type: "success",
           message: `Imported "${result.imported.join(", ")}"`,
@@ -125,13 +125,13 @@ export const TeamTemplateList = () => {
         const templates = await api.database.listTemplates();
         setTemplates(templates);
       } else if (result.skipped.length > 0) {
-        setImportStatuses((prev) => ({ ...prev, [template.filePath]: "idle" }));
+        setImportStatuses((prev) => ({ ...prev, [template.file_path]: "idle" }));
         addLog({
           type: "info",
           message: `Skipped "${result.skipped.join(", ")}" (already exists)`,
         });
       } else if (result.errors.length > 0) {
-        setImportStatuses((prev) => ({ ...prev, [template.filePath]: "error" }));
+        setImportStatuses((prev) => ({ ...prev, [template.file_path]: "error" }));
         addLog({
           type: "error",
           message: "Import failed",
@@ -141,11 +141,11 @@ export const TeamTemplateList = () => {
 
       // Clear status after a delay
       setTimeout(() => {
-        setImportStatuses((prev) => ({ ...prev, [template.filePath]: "idle" }));
+        setImportStatuses((prev) => ({ ...prev, [template.file_path]: "idle" }));
       }, 3000);
     } catch (e) {
       console.error("Failed to import template:", e);
-      setImportStatuses((prev) => ({ ...prev, [template.filePath]: "error" }));
+      setImportStatuses((prev) => ({ ...prev, [template.file_path]: "error" }));
       addLog({
         type: "error",
         message: `Failed to import "${template.name}"`,
@@ -154,12 +154,12 @@ export const TeamTemplateList = () => {
 
       // Clear error status after a delay
       setTimeout(() => {
-        setImportStatuses((prev) => ({ ...prev, [template.filePath]: "idle" }));
+        setImportStatuses((prev) => ({ ...prev, [template.file_path]: "idle" }));
       }, 3000);
     } finally {
       setImportingTemplates((prev) => {
         const next = new Set(prev);
-        next.delete(template.filePath);
+        next.delete(template.file_path);
         return next;
       });
     }
@@ -208,11 +208,11 @@ export const TeamTemplateList = () => {
 
       {teamTemplates.map((template) => (
         <TeamTemplateItem
-          key={template.filePath}
+          key={template.file_path}
           template={template}
           onImport={handleImport}
-          isImporting={importingTemplates.has(template.filePath)}
-          importStatus={importStatuses[template.filePath] || "idle"}
+          isImporting={importingTemplates.has(template.file_path)}
+          importStatus={importStatuses[template.file_path] || "idle"}
         />
       ))}
     </div>

--- a/apps/desktop/src/lib/adapters/tauri/index.ts
+++ b/apps/desktop/src/lib/adapters/tauri/index.ts
@@ -58,37 +58,7 @@ import type {
   TeamImportResult,
 } from "../../../types/schema";
 
-// Rust returns snake_case fields, this interface matches the Rust struct
-interface RustRecentProject {
-  id: string;
-  project_name: string;
-  output_path: string;
-  schema_xml: string;
-  variables: Record<string, string>;
-  variable_validation: Record<string, ValidationRule>;
-  template_id: string | null;
-  template_name: string | null;
-  folders_created: number;
-  files_created: number;
-  created_at: string;
-}
-
-/** Convert Rust snake_case RecentProject to TypeScript camelCase */
-function toRecentProject(p: RustRecentProject): RecentProject {
-  return {
-    id: p.id,
-    projectName: p.project_name,
-    outputPath: p.output_path,
-    schemaXml: p.schema_xml,
-    variables: p.variables,
-    variableValidation: p.variable_validation,
-    templateId: p.template_id,
-    templateName: p.template_name,
-    foldersCreated: p.folders_created,
-    filesCreated: p.files_created,
-    createdAt: p.created_at,
-  };
-}
+// RecentProject crosses IPC in the wire shape directly (codegen, #116).
 
 // ============================================================================
 // File System Adapter (Tauri)
@@ -269,17 +239,15 @@ class TauriDatabaseAdapter implements DatabaseAdapter {
   // Recent projects operations
 
   async listRecentProjects(): Promise<RecentProject[]> {
-    const projects = await invoke<RustRecentProject[]>("cmd_list_recent_projects");
-    return projects.map(toRecentProject);
+    return invoke<RecentProject[]>("cmd_list_recent_projects");
   }
 
   async getRecentProject(id: string): Promise<RecentProject | null> {
-    const p = await invoke<RustRecentProject | null>("cmd_get_recent_project", { id });
-    return p ? toRecentProject(p) : null;
+    return invoke<RecentProject | null>("cmd_get_recent_project", { id });
   }
 
   async addRecentProject(input: CreateRecentProjectInput): Promise<RecentProject> {
-    const p = await invoke<RustRecentProject>("cmd_add_recent_project", {
+    return invoke<RecentProject>("cmd_add_recent_project", {
       projectName: input.projectName,
       outputPath: input.outputPath,
       schemaXml: input.schemaXml,
@@ -290,7 +258,6 @@ class TauriDatabaseAdapter implements DatabaseAdapter {
       foldersCreated: input.foldersCreated,
       filesCreated: input.filesCreated,
     });
-    return toRecentProject(p);
   }
 
   async deleteRecentProject(id: string): Promise<boolean> {
@@ -552,86 +519,17 @@ class TauriWatchAdapter implements WatchAdapter {
 // ============================================================================
 
 // Rust returns snake_case fields, these interfaces match the Rust structs
-interface RustTeamLibrary {
-  id: string;
-  name: string;
-  path: string;
-  sync_interval: number;
-  last_sync_at: string | null;
-  is_enabled: boolean;
-  created_at: string;
-  updated_at: string;
-}
-
-interface RustTeamTemplate {
-  name: string;
-  description: string | null;
-  file_path: string;
-  modified_at: string;
-  size_bytes: number;
-}
-
-interface RustSyncLogEntry {
-  id: string;
-  library_id: string;
-  action: string;
-  template_name: string | null;
-  details: string | null;
-  created_at: string;
-}
-
-interface RustTeamImportResult {
-  imported: string[];
-  skipped: string[];
-  errors: string[];
-}
-
-/** Convert Rust snake_case TeamLibrary to TypeScript camelCase */
-function toTeamLibrary(lib: RustTeamLibrary): TeamLibrary {
-  return {
-    id: lib.id,
-    name: lib.name,
-    path: lib.path,
-    syncInterval: lib.sync_interval,
-    lastSyncAt: lib.last_sync_at,
-    isEnabled: lib.is_enabled,
-    createdAt: lib.created_at,
-    updatedAt: lib.updated_at,
-  };
-}
-
-/** Convert Rust snake_case TeamTemplate to TypeScript camelCase */
-function toTeamTemplate(t: RustTeamTemplate): TeamTemplate {
-  return {
-    name: t.name,
-    description: t.description,
-    filePath: t.file_path,
-    modifiedAt: t.modified_at,
-    sizeBytes: t.size_bytes,
-  };
-}
-
-/** Convert Rust snake_case SyncLogEntry to TypeScript camelCase */
-function toSyncLogEntry(entry: RustSyncLogEntry): SyncLogEntry {
-  return {
-    id: entry.id,
-    libraryId: entry.library_id,
-    action: entry.action as "scan" | "import" | "error",
-    templateName: entry.template_name,
-    details: entry.details,
-    createdAt: entry.created_at,
-  };
-}
+// Team library types cross IPC in the wire shape directly (codegen, #116).
+// `cmd_get_sync_log` returns `action` as an unconstrained string in Rust; the
+// frontend SyncLogEntry narrows it to the documented union.
 
 class TauriTeamLibraryAdapter implements TeamLibraryAdapter {
   async listTeamLibraries(): Promise<TeamLibrary[]> {
-    const libraries = await invoke<RustTeamLibrary[]>("cmd_list_team_libraries");
-    return libraries.map(toTeamLibrary);
+    return invoke<TeamLibrary[]>("cmd_list_team_libraries");
   }
 
   async addTeamLibrary(name: string, path: string): Promise<TeamLibrary> {
-    const lib = await invoke<RustTeamLibrary>("cmd_add_team_library", { name, path });
-    return toTeamLibrary(lib);
+    return invoke<TeamLibrary>("cmd_add_team_library", { name, path });
   }
 
   async updateTeamLibrary(
@@ -643,14 +541,13 @@ class TauriTeamLibraryAdapter implements TeamLibraryAdapter {
       isEnabled?: boolean;
     }
   ): Promise<TeamLibrary | null> {
-    const lib = await invoke<RustTeamLibrary | null>("cmd_update_team_library", {
+    return invoke<TeamLibrary | null>("cmd_update_team_library", {
       id,
       name: updates.name,
       path: updates.path,
       syncInterval: updates.syncInterval,
       isEnabled: updates.isEnabled,
     });
-    return lib ? toTeamLibrary(lib) : null;
   }
 
   async removeTeamLibrary(id: string): Promise<boolean> {
@@ -658,8 +555,7 @@ class TauriTeamLibraryAdapter implements TeamLibraryAdapter {
   }
 
   async scanTeamLibrary(libraryId: string): Promise<TeamTemplate[]> {
-    const templates = await invoke<RustTeamTemplate[]>("cmd_scan_team_library", { libraryId });
-    return templates.map(toTeamTemplate);
+    return invoke<TeamTemplate[]>("cmd_scan_team_library", { libraryId });
   }
 
   async getTeamTemplate(filePath: string): Promise<{
@@ -688,21 +584,15 @@ class TauriTeamLibraryAdapter implements TeamLibraryAdapter {
     filePath: string,
     strategy: DuplicateStrategy
   ): Promise<TeamImportResult> {
-    const result = await invoke<RustTeamImportResult>("cmd_import_team_template", {
+    return invoke<TeamImportResult>("cmd_import_team_template", {
       libraryId,
       filePath,
       strategy,
     });
-    return {
-      imported: result.imported,
-      skipped: result.skipped,
-      errors: result.errors,
-    };
   }
 
   async getSyncLog(libraryId: string | null, limit: number): Promise<SyncLogEntry[]> {
-    const entries = await invoke<RustSyncLogEntry[]>("cmd_get_sync_log", { libraryId, limit });
-    return entries.map(toSyncLogEntry);
+    return invoke<SyncLogEntry[]>("cmd_get_sync_log", { libraryId, limit });
   }
 }
 

--- a/apps/desktop/src/lib/adapters/tauri/plugin.ts
+++ b/apps/desktop/src/lib/adapters/tauri/plugin.ts
@@ -7,80 +7,19 @@ import { invoke } from "@tauri-apps/api/core";
 import type { PluginAdapter } from "../types";
 import type { Plugin, PluginManifest } from "../../../types/schema";
 
-// Rust returns snake_case fields, this interface matches the Rust struct
-interface RustPlugin {
-  id: string;
-  name: string;
-  version: string;
-  description: string | null;
-  path: string;
-  capabilities: string[];
-  file_types: string[];
-  user_settings: Record<string, unknown>;
-  is_enabled: boolean;
-  load_order: number;
-  installed_at: string;
-  updated_at: string;
-}
-
-/** Convert Rust snake_case Plugin to TypeScript camelCase */
-function toPlugin(p: RustPlugin): Plugin {
-  return {
-    id: p.id,
-    name: p.name,
-    version: p.version,
-    description: p.description,
-    path: p.path,
-    capabilities: p.capabilities as Plugin["capabilities"],
-    fileTypes: p.file_types,
-    userSettings: p.user_settings,
-    isEnabled: p.is_enabled,
-    loadOrder: p.load_order,
-    installedAt: p.installed_at,
-    updatedAt: p.updated_at,
-  };
-}
-
-// Rust manifest format
-interface RustPluginManifest {
-  name: string;
-  version: string;
-  description: string | null;
-  capabilities: string[];
-  file_types: string[];
-  main: string;
-  author: string | null;
-  license: string | null;
-}
-
-/** Convert Rust PluginManifest to TypeScript */
-function toPluginManifest(m: RustPluginManifest): PluginManifest {
-  return {
-    name: m.name,
-    version: m.version,
-    description: m.description ?? undefined,
-    capabilities: m.capabilities as PluginManifest["capabilities"],
-    fileTypes: m.file_types,
-    main: m.main,
-    author: m.author ?? undefined,
-    license: m.license ?? undefined,
-  };
-}
+// Plugin types cross IPC in the wire shape directly (codegen, #116).
 
 export class TauriPluginAdapter implements PluginAdapter {
   async listPlugins(): Promise<Plugin[]> {
-    const plugins = await invoke<RustPlugin[]>("cmd_list_plugins");
-    return plugins.map(toPlugin);
+    return invoke<Plugin[]>("cmd_list_plugins");
   }
 
   async getPlugin(id: string): Promise<Plugin | null> {
-    const plugin = await invoke<RustPlugin | null>("cmd_get_plugin", { id });
-    return plugin ? toPlugin(plugin) : null;
+    return invoke<Plugin | null>("cmd_get_plugin", { id });
   }
 
   async installPlugin(sourcePath: string): Promise<Plugin> {
-    const plugin = await invoke<RustPlugin>("cmd_install_plugin", { sourcePath });
-    return toPlugin(plugin);
+    return invoke<Plugin>("cmd_install_plugin", { sourcePath });
   }
 
   async uninstallPlugin(id: string): Promise<boolean> {
@@ -88,13 +27,11 @@ export class TauriPluginAdapter implements PluginAdapter {
   }
 
   async enablePlugin(id: string): Promise<Plugin | null> {
-    const plugin = await invoke<RustPlugin | null>("cmd_enable_plugin", { id });
-    return plugin ? toPlugin(plugin) : null;
+    return invoke<Plugin | null>("cmd_enable_plugin", { id });
   }
 
   async disablePlugin(id: string): Promise<Plugin | null> {
-    const plugin = await invoke<RustPlugin | null>("cmd_disable_plugin", { id });
-    return plugin ? toPlugin(plugin) : null;
+    return invoke<Plugin | null>("cmd_disable_plugin", { id });
   }
 
   async getPluginSettings(id: string): Promise<Record<string, unknown> | null> {
@@ -102,18 +39,15 @@ export class TauriPluginAdapter implements PluginAdapter {
   }
 
   async savePluginSettings(id: string, settings: Record<string, unknown>): Promise<Plugin | null> {
-    const plugin = await invoke<RustPlugin | null>("cmd_save_plugin_settings", { id, settings });
-    return plugin ? toPlugin(plugin) : null;
+    return invoke<Plugin | null>("cmd_save_plugin_settings", { id, settings });
   }
 
   async scanPlugins(): Promise<PluginManifest[]> {
-    const manifests = await invoke<RustPluginManifest[]>("cmd_scan_plugins");
-    return manifests.map(toPluginManifest);
+    return invoke<PluginManifest[]>("cmd_scan_plugins");
   }
 
   async syncPlugins(): Promise<Plugin[]> {
-    const plugins = await invoke<RustPlugin[]>("cmd_sync_plugins");
-    return plugins.map(toPlugin);
+    return invoke<Plugin[]>("cmd_sync_plugins");
   }
 }
 

--- a/apps/desktop/src/lib/adapters/web/indexeddb.ts
+++ b/apps/desktop/src/lib/adapters/web/indexeddb.ts
@@ -630,7 +630,7 @@ export class IndexedDBAdapter implements DatabaseAdapter {
         const projects = request.result as RecentProject[];
         // Sort by createdAt descending (newest first)
         projects.sort((a, b) =>
-          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+          new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
         );
         resolve(projects);
       };
@@ -665,16 +665,16 @@ export class IndexedDBAdapter implements DatabaseAdapter {
 
     const project: RecentProject = {
       id: generateUUID(),
-      projectName: input.projectName,
-      outputPath: input.outputPath,
-      schemaXml: input.schemaXml,
+      project_name: input.projectName,
+      output_path: input.outputPath,
+      schema_xml: input.schemaXml,
       variables: input.variables,
-      variableValidation: input.variableValidation,
-      templateId: input.templateId,
-      templateName: input.templateName,
-      foldersCreated: input.foldersCreated,
-      filesCreated: input.filesCreated,
-      createdAt: timestamp,
+      variable_validation: input.variableValidation,
+      template_id: input.templateId,
+      template_name: input.templateName,
+      folders_created: input.foldersCreated,
+      files_created: input.filesCreated,
+      created_at: timestamp,
     };
 
     return new Promise((resolve, reject) => {
@@ -690,7 +690,7 @@ export class IndexedDBAdapter implements DatabaseAdapter {
           if (all.length > MAX_RECENT_PROJECTS) {
             // Sort by createdAt ascending to find oldest
             all.sort((a, b) =>
-              new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+              new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
             );
             // Delete oldest entries
             const toDelete = all.slice(0, all.length - MAX_RECENT_PROJECTS);

--- a/apps/desktop/src/lib/plugins/runtime.ts
+++ b/apps/desktop/src/lib/plugins/runtime.ts
@@ -122,7 +122,7 @@ export class PluginRuntime {
   async loadPlugins(plugins: Plugin[], reload = false): Promise<void> {
     // Only load enabled file-processor plugins
     const fileProcessors = plugins.filter(
-      (p) => p.isEnabled && p.capabilities.includes("file-processor")
+      (p) => p.is_enabled && p.capabilities.includes("file-processor")
     );
 
     console.log(`Loading ${fileProcessors.length} file processor plugin(s)`);
@@ -187,14 +187,14 @@ export class PluginRuntime {
 
     for (const loaded of this.loadedPlugins.values()) {
       // Check if plugin handles this extension
-      const fileTypes = loaded.module.fileTypes || loaded.plugin.fileTypes;
+      const fileTypes = loaded.module.fileTypes || loaded.plugin.file_types;
       if (fileTypes.some((ft) => ft === extension || ft === `*`)) {
         processors.push(loaded);
       }
     }
 
     // Sort by load order
-    processors.sort((a, b) => a.plugin.loadOrder - b.plugin.loadOrder);
+    processors.sort((a, b) => a.plugin.load_order - b.plugin.load_order);
 
     return processors;
   }

--- a/apps/desktop/src/store/slices/pluginsSlice.ts
+++ b/apps/desktop/src/store/slices/pluginsSlice.ts
@@ -19,6 +19,6 @@ export const createPluginsSlice: StateCreator<PluginsSlice, [], [], PluginsSlice
 
   getEnabledPlugins: () => {
     const state = get();
-    return state.plugins.filter((p) => p.isEnabled);
+    return state.plugins.filter((p) => p.is_enabled);
   },
 });

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -61,6 +61,15 @@ import type {
   ValidationIssue as GeneratedValidationIssue,
   SchemaValidationResult as GeneratedSchemaValidationResult,
   ParseWithInheritanceResult as GeneratedParseWithInheritanceResult,
+  // Phase 3 (#116): translation-layer types now consumed directly. The Tauri
+  // adapter no longer rewrites snake_case wire fields to camelCase frontend
+  // fields, so the generated snake_case shape IS the frontend type.
+  RecentProject as GeneratedRecentProject,
+  TeamLibrary as GeneratedTeamLibrary,
+  TeamTemplate as GeneratedTeamTemplate,
+  SyncLogEntry as GeneratedSyncLogEntry,
+  Plugin as GeneratedPlugin,
+  PluginManifest as GeneratedPluginManifest,
 } from "./generated/types";
 
 /**
@@ -340,19 +349,12 @@ export type TemplateSortOption =
   | "usage_asc"
   | "usage_desc";
 
-export interface RecentProject {
-  id: string;
-  projectName: string;
-  outputPath: string;
-  schemaXml: string;
-  variables: Record<string, string>;
-  variableValidation: Record<string, ValidationRule>;
-  templateId: string | null;
-  templateName: string | null;
-  foldersCreated: number;
-  filesCreated: number;
-  createdAt: string;
-}
+export type RecentProject = Omit<
+  GeneratedRecentProject,
+  "variable_validation"
+> & {
+  variable_validation?: Record<string, ValidationRule>;
+};
 
 // ============================================================================
 // Settings Types
@@ -432,59 +434,20 @@ export type SchemaValidationResult = Omit<
  * Team libraries allow sharing templates across team members via network folders,
  * Dropbox, OneDrive, or other shared storage.
  */
-export interface TeamLibrary {
-  /** Unique identifier */
-  id: string;
-  /** Display name for the library */
-  name: string;
-  /** Full path to the shared folder */
-  path: string;
-  /** Sync interval in seconds (default: 300 = 5 minutes) */
-  syncInterval: number;
-  /** ISO timestamp of last successful scan, or null if never scanned */
-  lastSyncAt: string | null;
-  /** Whether this library is enabled for scanning */
-  isEnabled: boolean;
-  /** ISO timestamp when the library was added */
-  createdAt: string;
-  /** ISO timestamp when the library was last modified */
-  updatedAt: string;
-}
+export type TeamLibrary = GeneratedTeamLibrary;
 
 /**
  * A template found in a team library folder.
  * Represents metadata about a .sct file without loading its full content.
  */
-export interface TeamTemplate {
-  /** Template name (from the .sct file metadata) */
-  name: string;
-  /** Description from the template, if available */
-  description: string | null;
-  /** Full path to the .sct file */
-  filePath: string;
-  /** ISO timestamp when the file was last modified */
-  modifiedAt: string;
-  /** File size in bytes */
-  sizeBytes: number;
-}
+export type TeamTemplate = GeneratedTeamTemplate;
 
 /**
  * A sync log entry for auditing team library operations.
  */
-export interface SyncLogEntry {
-  /** Unique identifier */
-  id: string;
-  /** ID of the library this entry relates to */
-  libraryId: string;
-  /** Type of action: "scan", "import", or "error" */
+export type SyncLogEntry = Omit<GeneratedSyncLogEntry, "action"> & {
   action: "scan" | "import" | "error";
-  /** Name of the template involved (for import actions) */
-  templateName: string | null;
-  /** Additional details about the action */
-  details: string | null;
-  /** ISO timestamp when the action occurred */
-  createdAt: string;
-}
+};
 
 /**
  * Result of importing templates from a team library.
@@ -510,52 +473,12 @@ export type PluginCapability = GeneratedPluginCapability;
 /**
  * A registered plugin in the system.
  */
-export interface Plugin {
-  /** Unique identifier */
-  id: string;
-  /** Plugin name (from plugin.json) */
-  name: string;
-  /** Semantic version */
-  version: string;
-  /** Human-readable description */
-  description: string | null;
-  /** Full path to the plugin directory */
-  path: string;
-  /** Plugin capabilities (what hooks it provides) */
-  capabilities: PluginCapability[];
-  /** File extensions this plugin processes (for file-processor capability) */
-  fileTypes: string[];
-  /** User-configurable settings */
-  userSettings: Record<string, unknown>;
-  /** Whether the plugin is enabled */
-  isEnabled: boolean;
-  /** Load order (lower numbers load first) */
-  loadOrder: number;
-  /** ISO timestamp when the plugin was installed */
-  installedAt: string;
-  /** ISO timestamp when the plugin was last updated */
-  updatedAt: string;
-}
+export type Plugin = Omit<GeneratedPlugin, "user_settings"> & {
+  user_settings: Record<string, unknown>;
+};
 
 /**
  * Plugin manifest structure (plugin.json).
  * This is the format plugins use to describe themselves.
  */
-export interface PluginManifest {
-  /** Unique plugin name */
-  name: string;
-  /** Semantic version */
-  version: string;
-  /** Human-readable description */
-  description?: string;
-  /** Plugin capabilities */
-  capabilities: PluginCapability[];
-  /** File extensions for file processors */
-  fileTypes?: string[];
-  /** Main entry point (default: "index.js") */
-  main?: string;
-  /** Plugin author */
-  author?: string;
-  /** License */
-  license?: string;
-}
+export type PluginManifest = WithoutNullFields<GeneratedPluginManifest>;


### PR DESCRIPTION
Completes the codegen migration from #102 / ADR-0003 by removing the manual snake_case↔camelCase translation in the Tauri adapter for the final 6 IPC types.

## What

- **Drop translation:** removes 13 `Rust*` wire-shape interfaces and `to*` mappers from `tauri/index.ts` and `tauri/plugin.ts`. `invoke()` now returns the generated wire type directly.
- **Shared swaps:** `RecentProject`, `TeamLibrary`, `TeamTemplate`, `SyncLogEntry`, `Plugin`, `PluginManifest` in `packages/shared/src/types.ts` become narrowed re-exports over the generated types.
  - `SyncLogEntry` narrows `action` to the documented `"scan" | "import" | "error"` union.
  - `Plugin` narrows `user_settings` to `Record<string, unknown>` (vs generated `JsonValue`).
- **Frontend renames:** ~78 camelCase field accesses converted to snake_case across `RecentProjectsSection`, `PluginManager`, `RightPanel`, `SettingsModal`, `TeamTemplateList`, plugin runtime, and the web indexeddb adapter. Invoke argument names stay camelCase (Tauri 2 auto-converts to snake_case on the Rust side).

## Verification

- Full TS suite **368/368** (`tsc --noEmit` clean).
- Full Rust suite **250/250**.
- Codegen drift test idempotent.
- Wire format unchanged — no serde renames touched.

Closes #116. Also closes #114 since this completes the type sweep from #102/#114/#115.