### PR TITLE
feat: enforce VariableName brand on Variable/ValidationError/VariableDefinition (ADR-0001)

### DIFF
--- a/apps/desktop/src/components/LeftPanel.test.tsx
+++ b/apps/desktop/src/components/LeftPanel.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, waitFor, within, act } from "@testing-librar
 import { LeftPanel } from "./LeftPanel";
 import { useAppStore } from "../store/appStore";
 import type { Template, SchemaTree, Variable, ParseWithInheritanceResult } from "../types/schema";
+import { asVariableName } from "@structure-creator/shared";
 
 // ============================================================================
 // Mock Setup
@@ -463,8 +464,8 @@ describe("LeftPanel", () => {
     describe("variable display", () => {
       it("renders variables list", async () => {
         setupWithVariables([
-          { name: "%PROJECT_NAME%", value: "my-project" },
-          { name: "%VERSION%", value: "1.0.0" },
+          { name: asVariableName("%PROJECT_NAME%"), value: "my-project" },
+          { name: asVariableName("%VERSION%"), value: "1.0.0" },
         ]);
         renderLeftPanel();
         await waitForDataLoad();
@@ -474,7 +475,7 @@ describe("LeftPanel", () => {
       });
 
       it("displays variable values in inputs", async () => {
-        setupWithVariables([{ name: "%PROJECT_NAME%", value: "my-project" }]);
+        setupWithVariables([{ name: asVariableName("%PROJECT_NAME%"), value: "my-project" }]);
         renderLeftPanel();
         await waitForDataLoad();
 
@@ -484,7 +485,7 @@ describe("LeftPanel", () => {
 
       it("displays variable descriptions", async () => {
         setupWithVariables([
-          { name: "%PROJECT_NAME%", value: "", description: "The name of your project" },
+          { name: asVariableName("%PROJECT_NAME%"), value: "", description: "The name of your project" },
         ]);
         renderLeftPanel();
         await waitForDataLoad();
@@ -493,9 +494,9 @@ describe("LeftPanel", () => {
       });
 
       it("displays validation errors", async () => {
-        setupWithVariables([{ name: "%PROJECT_NAME%", value: "" }]);
+        setupWithVariables([{ name: asVariableName("%PROJECT_NAME%"), value: "" }]);
         useAppStore.getState().setValidationErrors([
-          { variable_name: "PROJECT_NAME", message: "Required field" },
+          { variable_name: asVariableName("PROJECT_NAME"), message: "Required field" },
         ]);
         renderLeftPanel();
         await waitForDataLoad();
@@ -506,7 +507,7 @@ describe("LeftPanel", () => {
 
     describe("variable editing", () => {
       it("updates variable value on input", async () => {
-        setupWithVariables([{ name: "%PROJECT_NAME%", value: "old-value" }]);
+        setupWithVariables([{ name: asVariableName("%PROJECT_NAME%"), value: "old-value" }]);
         renderLeftPanel();
         await waitForDataLoad();
 
@@ -589,7 +590,7 @@ describe("LeftPanel", () => {
 
     describe("removing variables", () => {
       it("removes variable when remove button is clicked", async () => {
-        setupWithVariables([{ name: "%PROJECT_NAME%", value: "test" }]);
+        setupWithVariables([{ name: asVariableName("%PROJECT_NAME%"), value: "test" }]);
         renderLeftPanel();
         await waitForDataLoad();
 
@@ -604,7 +605,7 @@ describe("LeftPanel", () => {
 
     describe("validation configuration popover", () => {
       it("opens validation popover when settings button is clicked", async () => {
-        setupWithVariables([{ name: "%PROJECT_NAME%", value: "test" }]);
+        setupWithVariables([{ name: asVariableName("%PROJECT_NAME%"), value: "test" }]);
         renderLeftPanel();
         await waitForDataLoad();
 
@@ -616,7 +617,7 @@ describe("LeftPanel", () => {
       });
 
       it("toggles required checkbox", async () => {
-        setupWithVariables([{ name: "%PROJECT_NAME%", value: "test" }]);
+        setupWithVariables([{ name: asVariableName("%PROJECT_NAME%"), value: "test" }]);
         renderLeftPanel();
         await waitForDataLoad();
 
@@ -629,7 +630,7 @@ describe("LeftPanel", () => {
       });
 
       it("closes popover when Done is clicked", async () => {
-        setupWithVariables([{ name: "%PROJECT_NAME%", value: "test" }]);
+        setupWithVariables([{ name: asVariableName("%PROJECT_NAME%"), value: "test" }]);
         renderLeftPanel();
         await waitForDataLoad();
 

--- a/apps/desktop/src/components/LeftPanel.tsx
+++ b/apps/desktop/src/components/LeftPanel.tsx
@@ -24,6 +24,7 @@ import type { Template, ValidationRule, TemplateSortOption } from "../types/sche
 import { TRANSFORMATIONS, DATE_FORMATS } from "../types/schema";
 import { SHORTCUT_EVENTS, getShortcutLabel } from "../constants/shortcuts";
 import type { ReactNode } from "react";
+import { asVariableName } from "@structure-creator/shared";
 
 interface LeftPanelProps {
   /** Ref for the search input, used by keyboard shortcuts */
@@ -320,7 +321,7 @@ export const LeftPanel = ({ searchInputRef, onImportExportModalChange }: LeftPan
 
       if (Object.keys(mergedVariables).length > 0) {
         const loadedVariables = Object.entries(mergedVariables).map(([name, value]) => ({
-          name,
+          name: asVariableName(name),
           value,
           validation: mergedValidation[name],
         }));
@@ -526,7 +527,7 @@ export const LeftPanel = ({ searchInputRef, onImportExportModalChange }: LeftPan
             // (matches template loading behavior - new schema replaces previous variables)
             if (Object.keys(result.mergedVariables).length > 0) {
               const loadedVariables = Object.entries(result.mergedVariables).map(([name, value]) => ({
-                name,
+                name: asVariableName(name),
                 value,
                 validation: result.mergedVariableValidation[name],
               }));

--- a/apps/desktop/src/components/RecentProjectsSection.tsx
+++ b/apps/desktop/src/components/RecentProjectsSection.tsx
@@ -9,6 +9,7 @@ import {
   UploadIcon,
 } from "./Icons";
 import type { RecentProject } from "../types/schema";
+import { asVariableName } from "@structure-creator/shared";
 
 /** Format relative time (e.g., "2 days ago", "just now") */
 function formatRelativeTime(isoDate: string): string {
@@ -64,7 +65,7 @@ export const RecentProjectsSection = () => {
 
       // Always set variables (clears previous if project has none)
       const loadedVariables = Object.entries(project.variables).map(([name, value]) => ({
-        name,
+        name: asVariableName(name),
         value,
         validation: project.variable_validation?.[name],
       }));

--- a/apps/desktop/src/components/wizard/TemplateWizard.tsx
+++ b/apps/desktop/src/components/wizard/TemplateWizard.tsx
@@ -7,6 +7,7 @@ import { WizardStep } from "./WizardStep";
 import { WizardPreview } from "./WizardPreview";
 import { WizardErrorBoundary } from "./WizardErrorBoundary";
 import { XIcon, LoaderIcon } from "../Icons";
+import { asVariableName } from "@structure-creator/shared";
 import {
   parseWizardConfig,
   applyWizardModifiers,
@@ -281,7 +282,7 @@ export const TemplateWizard = () => {
 
       // Convert to Variable array format for the store
       const loadedVariables: Variable[] = Object.entries(finalVariables).map(([name, value]) => ({
-        name,
+        name: asVariableName(name),
         value,
         validation: mergedValidation[name],
       }));

--- a/apps/desktop/src/lib/adapters/web/schema-parser.ts
+++ b/apps/desktop/src/lib/adapters/web/schema-parser.ts
@@ -13,6 +13,7 @@ import type {
   VariableDefinition,
 } from "../../../types/schema";
 import { MAX_DIRECTORY_SCAN_DEPTH, MAX_SCHEMA_DEPTH, validatePathComponent, calculateSchemaStats } from "./constants";
+import { asVariableName } from "@structure-creator/shared";
 
 /**
  * Validate a repeat_as variable name.
@@ -105,7 +106,7 @@ const parseVariableDefinitions = (element: Element): VariableDefinition[] | unde
     const name = varEl.getAttribute("name");
     if (!name) continue; // Name is required
 
-    const def: VariableDefinition = { name };
+    const def: VariableDefinition = { name: asVariableName(name) };
 
     const description = varEl.getAttribute("description");
     if (description) def.description = description;

--- a/apps/desktop/src/lib/adapters/web/transforms.ts
+++ b/apps/desktop/src/lib/adapters/web/transforms.ts
@@ -1,3 +1,4 @@
+import { asVariableName } from "@structure-creator/shared";
 /**
  * Variable transformation and substitution for web mode.
  * Port of the Rust transforms.rs functionality.
@@ -398,7 +399,7 @@ export const validateVariables = (
     // Check required
     if (rule.required && (!value || value.trim() === "")) {
       errors.push({
-        variable_name: cleanName,
+        variable_name: asVariableName(cleanName),
         message: `${cleanName} is required`,
       });
       continue; // Skip other validations if required check fails
@@ -412,7 +413,7 @@ export const validateVariables = (
     // Check minLength
     if (rule.minLength !== undefined && value.length < rule.minLength) {
       errors.push({
-        variable_name: cleanName,
+        variable_name: asVariableName(cleanName),
         message: `${cleanName} must be at least ${rule.minLength} characters`,
       });
     }
@@ -420,7 +421,7 @@ export const validateVariables = (
     // Check maxLength
     if (rule.maxLength !== undefined && value.length > rule.maxLength) {
       errors.push({
-        variable_name: cleanName,
+        variable_name: asVariableName(cleanName),
         message: `${cleanName} must be at most ${rule.maxLength} characters`,
       });
     }
@@ -430,7 +431,7 @@ export const validateVariables = (
       // Check for potentially dangerous regex patterns (ReDoS prevention)
       if (isPotentiallyDangerousRegex(rule.pattern)) {
         errors.push({
-          variable_name: cleanName,
+          variable_name: asVariableName(cleanName),
           message: `Validation pattern for ${cleanName} was rejected for security reasons`,
         });
         continue;
@@ -444,13 +445,13 @@ export const validateVariables = (
           : value;
         if (!regex.test(testValue)) {
           errors.push({
-            variable_name: cleanName,
+            variable_name: asVariableName(cleanName),
             message: `${cleanName} does not match pattern: ${rule.pattern}`,
           });
         }
       } catch (e) {
         errors.push({
-          variable_name: cleanName,
+          variable_name: asVariableName(cleanName),
           message: `Invalid regex pattern for ${cleanName}: ${rule.pattern}`,
         });
       }

--- a/apps/desktop/src/store/appStore.variables.test.ts
+++ b/apps/desktop/src/store/appStore.variables.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { useAppStore } from "./appStore";
 import type { Variable, VariableDefinition } from "../types/schema";
+import { asVariableName } from "@structure-creator/shared";
 
 describe("appStore variable handling", () => {
   beforeEach(() => {
@@ -22,7 +23,7 @@ describe("appStore variable handling", () => {
     });
 
     it("does not duplicate existing variables", () => {
-      const existing: Variable[] = [{ name: "%CLIENT_NAME%", value: "Existing Value" }];
+      const existing: Variable[] = [{ name: asVariableName("%CLIENT_NAME%"), value: "Existing Value" }];
       useAppStore.getState().setVariables(existing);
 
       useAppStore.getState().mergeDetectedVariables(["%CLIENT_NAME%", "%NEW_VAR%"]);
@@ -38,7 +39,7 @@ describe("appStore variable handling", () => {
     it("applies helper text from definitions to new variables", () => {
       const definitions: VariableDefinition[] = [
         {
-          name: "CLIENT_NAME",
+          name: asVariableName("CLIENT_NAME"),
           description: "The client company name",
           placeholder: "Enter client name...",
           example: "Acme Corp",
@@ -58,7 +59,7 @@ describe("appStore variable handling", () => {
     it("applies validation rules from definitions to new variables", () => {
       const definitions: VariableDefinition[] = [
         {
-          name: "PROJECT_NAME",
+          name: asVariableName("PROJECT_NAME"),
           required: true,
           pattern: "^[a-z-]+$",
           minLength: 3,
@@ -79,12 +80,12 @@ describe("appStore variable handling", () => {
 
     it("applies helper text to existing variables without overwriting", () => {
       // Set up existing variable without helper text
-      const existing: Variable[] = [{ name: "%CLIENT_NAME%", value: "My Client" }];
+      const existing: Variable[] = [{ name: asVariableName("%CLIENT_NAME%"), value: "My Client" }];
       useAppStore.getState().setVariables(existing);
 
       const definitions: VariableDefinition[] = [
         {
-          name: "CLIENT_NAME",
+          name: asVariableName("CLIENT_NAME"),
           description: "The client company name",
           placeholder: "Enter client name...",
           example: "Acme Corp",
@@ -105,7 +106,7 @@ describe("appStore variable handling", () => {
       // Set up existing variable with helper text
       const existing: Variable[] = [
         {
-          name: "%CLIENT_NAME%",
+          name: asVariableName("%CLIENT_NAME%"),
           value: "My Client",
           description: "Custom description",
           placeholder: "Custom placeholder",
@@ -115,7 +116,7 @@ describe("appStore variable handling", () => {
 
       const definitions: VariableDefinition[] = [
         {
-          name: "CLIENT_NAME",
+          name: asVariableName("CLIENT_NAME"),
           description: "Definition description",
           placeholder: "Definition placeholder",
           example: "Acme Corp",
@@ -135,7 +136,7 @@ describe("appStore variable handling", () => {
       // Set up existing variable with some validation
       const existing: Variable[] = [
         {
-          name: "%PROJECT_NAME%",
+          name: asVariableName("%PROJECT_NAME%"),
           value: "test",
           validation: {
             required: true,
@@ -146,7 +147,7 @@ describe("appStore variable handling", () => {
 
       const definitions: VariableDefinition[] = [
         {
-          name: "PROJECT_NAME",
+          name: asVariableName("PROJECT_NAME"),
           required: false, // Should not overwrite
           pattern: "^[a-z]+$",
           minLength: 3,
@@ -164,7 +165,7 @@ describe("appStore variable handling", () => {
     it("handles variables without matching definitions", () => {
       const definitions: VariableDefinition[] = [
         {
-          name: "OTHER_VAR",
+          name: asVariableName("OTHER_VAR"),
           description: "Some other variable",
         },
       ];
@@ -181,7 +182,7 @@ describe("appStore variable handling", () => {
       // Set up existing variable that already has all definition fields
       const existing: Variable[] = [
         {
-          name: "%CLIENT_NAME%",
+          name: asVariableName("%CLIENT_NAME%"),
           value: "My Client",
           description: "Already has description",
           placeholder: "Already has placeholder",
@@ -196,7 +197,7 @@ describe("appStore variable handling", () => {
       // Merge with definitions that don't add anything new
       const definitions: VariableDefinition[] = [
         {
-          name: "CLIENT_NAME",
+          name: asVariableName("CLIENT_NAME"),
           description: "Definition description",
           placeholder: "Definition placeholder",
           example: "Definition example",
@@ -217,7 +218,7 @@ describe("appStore variable handling", () => {
       const store = useAppStore.getState();
       store.addVariable("%CLIENT_NAME%", "");
       store.setValidationErrors([
-        { variable_name: "CLIENT_NAME", message: "required" },
+        { variable_name: asVariableName("CLIENT_NAME"), message: "required" },
       ]);
 
       store.updateVariable("CLIENT_NAME", "Acme");
@@ -230,8 +231,8 @@ describe("appStore variable handling", () => {
 
     it("normalizes delimited names on setVariables (e.g. loaded from persisted data)", () => {
       useAppStore.getState().setVariables([
-        { name: "%CLIENT_NAME%", value: "Acme" },
-        { name: "REGION", value: "us" },
+        { name: asVariableName("%CLIENT_NAME%"), value: "Acme" },
+        { name: asVariableName("REGION"), value: "us" },
       ]);
 
       const state = useAppStore.getState();
@@ -241,8 +242,8 @@ describe("appStore variable handling", () => {
 
     it("removes a variable and clears its error when given a token form", () => {
       const store = useAppStore.getState();
-      store.setVariables([{ name: "FOO", value: "x" }]);
-      store.setValidationErrors([{ variable_name: "FOO", message: "bad" }]);
+      store.setVariables([{ name: asVariableName("FOO"), value: "x" }]);
+      store.setValidationErrors([{ variable_name: asVariableName("FOO"), message: "bad" }]);
 
       store.removeVariable("%FOO%");
 

--- a/apps/desktop/src/utils/variableName.ts
+++ b/apps/desktop/src/utils/variableName.ts
@@ -1,37 +1,11 @@
 /**
- * The variable-name convention (ADR-0001).
- *
- * A **Variable name** is the canonical clean identifier (e.g. `NAME`). A
- * **Variable token** is its delimited edge form (`%NAME%`) as it appears in
- * schema text and on the IPC wire. This module owns the conversion between the
- * two so callers never re-derive the `%` convention.
+ * Re-export the variable-name module from the shared package so existing
+ * `../utils/variableName` imports in this app continue to resolve. The
+ * canonical home is `@structure-creator/shared` (ADR-0001).
  */
-
-/** A clean, canonical variable name. Constructed only via {@link asVariableName}. */
-export type VariableName = string & { readonly __brand: "VariableName" };
-
-/**
- * Normalize a raw string to a clean {@link VariableName}, stripping a single
- * surrounding `%` delimiter. Idempotent.
- */
-export const asVariableName = (raw: string): VariableName =>
-  raw.replace(/^%|%$/g, "") as VariableName;
-
-/**
- * Produce the {@link VariableName}'s **Variable token** (`%NAME%`) for an
- * outbound edge (IPC to the native backend, or template-substitution scan).
- */
-export const toToken = (name: VariableName): string => `%${name}%`;
-
-/**
- * Rewrite a variable-name-keyed map to its **Variable token** keys (`%NAME%`),
- * for outbound IPC to the native backend whose lookups use the token form.
- * Idempotent on keys that are already tokens.
- */
-export const toTokenKeys = <V>(map: Record<string, V>): Record<string, V> => {
-  const out: Record<string, V> = {};
-  for (const [key, value] of Object.entries(map)) {
-    out[toToken(asVariableName(key))] = value;
-  }
-  return out;
-};
+export {
+  asVariableName,
+  toToken,
+  toTokenKeys,
+  type VariableName,
+} from "@structure-creator/shared";

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,3 +3,6 @@ export * from './types';
 
 // Re-export templating utilities
 export * from './templating';
+
+// Variable-name convention (ADR-0001)
+export * from './variableName';

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -18,6 +18,8 @@
 export const NODE_TYPES = ["folder", "file", "if", "else", "repeat"] as const;
 export type NodeType = (typeof NODE_TYPES)[number];
 
+import type { VariableName } from "./variableName";
+
 // IPC type shapes are generated from the Rust structs via specta (ADR-0003,
 // issues #97 + #102). See `./generated/types.ts` and the drift test
 // `ipc_types_match_committed_typescript` in apps/desktop/src-tauri.
@@ -105,7 +107,15 @@ export type SchemaNode = WithoutNullFields<
 
 export type SchemaHooks = WithoutNullFields<GeneratedSchemaHooks>;
 export type SchemaStats = WithoutNullFields<GeneratedSchemaStats>;
-export type VariableDefinition = WithoutNullFields<GeneratedVariableDefinition>;
+
+/** Variable definition parsed from a `<variable>` element in the schema.
+ *  `name` is branded as {@link VariableName} (ADR-0001 / #103). */
+export type VariableDefinition = Omit<
+  WithoutNullFields<GeneratedVariableDefinition>,
+  "name"
+> & {
+  name: VariableName;
+};
 
 /** Tree of schema nodes plus parse-time metadata (stats, hooks, defs). */
 export type SchemaTree = WithoutNullFields<
@@ -122,8 +132,13 @@ export type SchemaTree = WithoutNullFields<
 
 export type ValidationRule = WithoutNullFields<GeneratedValidationRule>;
 
+/**
+ * A user-supplied variable held in the store. `name` is branded as
+ * {@link VariableName} (ADR-0001 / #103) so a delimited or raw string cannot
+ * enter the store without going through `asVariableName`.
+ */
 export interface Variable {
-  name: string;
+  name: VariableName;
   value: string;
   validation?: ValidationRule;
   /** Description explaining what this variable is for */
@@ -134,7 +149,11 @@ export interface Variable {
   example?: string;
 }
 
-export type ValidationError = GeneratedValidationError;
+/** A validation error from the backend. `variable_name` is branded
+ *  ({@link VariableName}) to match the store's canonical form. */
+export type ValidationError = Omit<GeneratedValidationError, "variable_name"> & {
+  variable_name: VariableName;
+};
 
 // ============================================================================
 // IPC Result + Diff Types (generated, ADR-0003)

--- a/packages/shared/src/variableName.ts
+++ b/packages/shared/src/variableName.ts
@@ -1,0 +1,37 @@
+/**
+ * The variable-name convention (ADR-0001).
+ *
+ * A **Variable name** is the canonical clean identifier (e.g. `NAME`). A
+ * **Variable token** is its delimited edge form (`%NAME%`) as it appears in
+ * schema text and on the IPC wire. This module owns the conversion between the
+ * two so callers never re-derive the `%` convention.
+ */
+
+/** A clean, canonical variable name. Constructed only via {@link asVariableName}. */
+export type VariableName = string & { readonly __brand: "VariableName" };
+
+/**
+ * Normalize a raw string to a clean {@link VariableName}, stripping a single
+ * surrounding `%` delimiter. Idempotent.
+ */
+export const asVariableName = (raw: string): VariableName =>
+  raw.replace(/^%|%$/g, "") as VariableName;
+
+/**
+ * Produce the {@link VariableName}'s **Variable token** (`%NAME%`) for an
+ * outbound edge (IPC to the native backend, or template-substitution scan).
+ */
+export const toToken = (name: VariableName): string => `%${name}%`;
+
+/**
+ * Rewrite a variable-name-keyed map to its **Variable token** keys (`%NAME%`),
+ * for outbound IPC to the native backend whose lookups use the token form.
+ * Idempotent on keys that are already tokens.
+ */
+export const toTokenKeys = <V>(map: Record<string, V>): Record<string, V> => {
+  const out: Record<string, V> = {};
+  for (const [key, value] of Object.entries(map)) {
+    out[toToken(asVariableName(key))] = value;
+  }
+  return out;
+};


### PR DESCRIPTION
Implements #103 — the final ADR-0001 slice. The codegen migration (closed via #117) made this approachable without a Rust newtype: the brand lives entirely in the TS narrowing layer, so the wire format is untouched and the codegen drift test still validates it.

## What

- **Hoist** `VariableName`, `asVariableName`, `toToken`, `toTokenKeys` from `apps/desktop/src/utils/variableName.ts` into `packages/shared/src/variableName.ts` so the brand type is in scope where the IPC types are defined. The desktop utils file becomes a re-export shim (zero churn for existing imports).
- **Narrow** in `packages/shared/src/types.ts`:
  - `Variable.name: VariableName`
  - `ValidationError.variable_name: VariableName`
  - `VariableDefinition.name: VariableName`
  All three via `Omit` + intersection so Rust/generated stay `string`; the brand is pure compile-time.
- **Call-site wraps:** `asVariableName(...)` added at the construction sites the compiler flagged — web `schema-parser` (VariableDefinition), web `transforms` (ValidationError, 6 sites), `LeftPanel` / `RecentProjectsSection` / `TemplateWizard` `loadedVariables`, plus test fixtures.

## Effect

A raw `string` (or delimited `"%NAME%"`) can no longer enter `Variable.name` etc. Compiler enforces the convention; the runtime safety from ADR-0001/#98 is now backed by a type-level guarantee.

## Verification

- Full TS suite **368/368** (`tsc --noEmit` clean).
- Full Rust suite **250/250**.
- Existing `variableName` module tests (7/7) still pass through the desktop shim; brand still enforced.
- Wire format unchanged; codegen drift test idempotent.

Closes #103. With #103 landed, ADR-0001 is fully implemented (module + clean-canonical adoption + brand enforcement).