### PR TITLE
fix(desktop): case-preserved variable substitution in web target (#112)

### DIFF
--- a/apps/desktop/src/lib/adapters/web/expand-tree.ts
+++ b/apps/desktop/src/lib/adapters/web/expand-tree.ts
@@ -1,20 +1,5 @@
 import type { SchemaNode, SchemaTree } from "@structure-creator/shared";
-
-/**
- * Case-preserving variable substitution for path/name expansion. Mirrors the
- * Rust target's substitution: looks the captured name up verbatim, so a
- * lowercase iteration var (`%i%`) resolves against a `%i%`-keyed entry. This
- * is distinct from the web engine's `substituteVariables`, which uppercases
- * the lookup key for user-facing tokens.
- */
-const substituteInName = (
-  text: string,
-  variables: Record<string, string>
-): string =>
-  text.replace(
-    /%([A-Za-z_][A-Za-z0-9_]*)%/g,
-    (match, name) => variables[`%${name}%`] ?? match
-  );
+import { substituteVariables } from "./transforms";
 
 /**
  * Pure tree expander: given a parsed schema and variable map, return the
@@ -43,7 +28,7 @@ const walk = (
   paths: string[],
   variables: Record<string, string>
 ): void => {
-  const name = substituteInName(node.name, variables);
+  const name = substituteVariables(node.name, variables);
   const path = prefix ? `${prefix}/${name}` : name;
 
   if (node.type === "folder") {
@@ -121,7 +106,7 @@ const parseRepeatCount = (
   variables: Record<string, string>
 ): number => {
   if (!raw) return 0;
-  const substituted = substituteInName(raw, variables);
+  const substituted = substituteVariables(raw, variables);
   const n = Number.parseInt(substituted, 10);
   if (!Number.isFinite(n) || n < 0) return 0;
   return n;

--- a/apps/desktop/src/lib/adapters/web/transforms.ts
+++ b/apps/desktop/src/lib/adapters/web/transforms.ts
@@ -308,8 +308,10 @@ export const substituteVariables = (
   variables: Record<string, string>
 ): string => {
   return text.replace(VARIABLE_REGEX, (match, name, transform) => {
-    // Build the variable key with % delimiters for lookup
-    const key = `%${name.toUpperCase()}%`;
+    // Case-preserved lookup matches the Rust target's substitute_variables
+    // (ADR-0002 / #112). Repeat-loop iteration variables (`%i%`, `%item%`)
+    // are lowercase by convention and require this.
+    const key = `%${name}%`;
     const value = variables[key];
 
     if (value === undefined) {

--- a/fixtures/substitution.json
+++ b/fixtures/substitution.json
@@ -33,5 +33,10 @@
     "template": "keep %MISSING% as-is",
     "variables": {},
     "expected": "keep %MISSING% as-is"
+  },
+  {
+    "template": "iter-%i%-%i%",
+    "variables": { "%i%": "0" },
+    "expected": "iter-0-0"
   }
 ]


### PR DESCRIPTION
Implements #112 — the case-uppercase divergence the golden-vector substitution contract surfaced in #101.

## What

- Drop `.toUpperCase()` in `apps/desktop/src/lib/adapters/web/transforms.ts` `substituteVariables`. Lookup now uses the captured name verbatim, matching Rust's `substitute_variables`.
- Add a lowercase `%i%` case to `fixtures/substitution.json` — runs against **both** targets via the existing contract test; both now agree.
- Drop the workaround `substituteInName` helper in `apps/desktop/src/lib/adapters/web/expand-tree.ts` and use `substituteVariables` directly. One fewer parallel implementation to drift.

## Convention recorded

Rust is the spec per ADR-0002: variable tokens are looked up verbatim. The previous web behavior — uppercasing the lookup so `%i%` → `%I%` — was a divergence, not a feature. Schemas that wrote `%date%` (lowercase) relying on the prior coercion will no longer substitute; conventional usage (UI + docs) always shows uppercase user-facing tokens, so blast radius is small.

## Verification

- Full TS suite **369/369** (+1 substitution contract case).
- `tsc --noEmit` clean.
- Full Rust suite **251/251**.

Closes #112