### PR TITLE
feat: golden-vector parser parity contract (ADR-0002 / #96)

### DIFF
--- a/apps/desktop/src-tauri/src/schema.rs
+++ b/apps/desktop/src-tauri/src/schema.rs
@@ -2762,6 +2762,35 @@ export const EXTENSION = true;
         assert!(tree.variable_definitions.is_none());
     }
 
+    // Golden-vector parser parity contract (ADR-0002 / #96): the same XML
+    // schema fixture is parsed by both the Rust target (this test) and the
+    // web target. Each target serializes its parsed tree to JSON and compares
+    // against the committed `expected` tree in the fixture. Divergence fails.
+    #[test]
+    fn test_schema_parse_matches_golden_contract() {
+        #[derive(serde::Deserialize)]
+        struct Case {
+            name: String,
+            xml: String,
+            expected: serde_json::Value,
+        }
+
+        let fixture = include_str!("../../../../fixtures/schema-parse.json");
+        let cases: Vec<Case> = serde_json::from_str(fixture).expect("valid fixture JSON");
+        assert!(!cases.is_empty(), "schema-parse fixture must contain cases");
+
+        for case in cases {
+            let tree = parse_xml_schema(&case.xml)
+                .unwrap_or_else(|e| panic!("case '{}' parse error: {}", case.name, e));
+            let got = serde_json::to_value(&tree).expect("serialize parsed tree");
+            assert_eq!(
+                got, case.expected,
+                "case '{}': parser output diverged from fixture",
+                case.name
+            );
+        }
+    }
+
     // Type-drift codegen (ADR-0003 / issue #97): the TypeScript wire type for
     // SchemaNode is generated from this Rust struct via specta. The generated
     // file is checked in at packages/shared/src/generated/schemaNode.ts; any

--- a/apps/desktop/src/contract/schema-parse.contract.test.ts
+++ b/apps/desktop/src/contract/schema-parse.contract.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, it, expect } from "vitest";
+import { parseSchema } from "../lib/adapters/web/schema-parser";
+
+/**
+ * Golden-vector parser parity contract (ADR-0002 / #96).
+ *
+ * The same XML schema fixture is parsed by both the web target (this test,
+ * via DOMParser-backed `parseSchema`) and the Rust target (Rust contract
+ * `test_schema_parse_matches_golden_contract`). Each serializes its parsed
+ * tree to JSON and asserts equality against the committed `expected` tree
+ * in the fixture, so parser divergence between the two implementations
+ * fails CI.
+ */
+interface ParseCase {
+  name: string;
+  xml: string;
+  expected: unknown;
+}
+
+const fixturePath = resolve(process.cwd(), "../../fixtures/schema-parse.json");
+const cases: ParseCase[] = JSON.parse(readFileSync(fixturePath, "utf-8"));
+
+/**
+ * Round-trip through JSON so the comparison ignores key order, function
+ * properties, and any object identity differences the parsers might emit.
+ */
+const normalize = (value: unknown): unknown => JSON.parse(JSON.stringify(value));
+
+describe("schema-parse golden-vector contract", () => {
+  it("loads cases from the shared fixture", () => {
+    expect(cases.length).toBeGreaterThan(0);
+  });
+
+  it.each(cases)("$name", ({ xml, expected }) => {
+    const tree = parseSchema(xml);
+    expect(normalize(tree)).toEqual(expected);
+  });
+});

--- a/apps/desktop/src/lib/adapters/web/schema-parser.ts
+++ b/apps/desktop/src/lib/adapters/web/schema-parser.ts
@@ -155,7 +155,12 @@ const parseNode = (element: Element, depth: number): SchemaNode => {
   }
 
   const tagName = element.tagName.toLowerCase();
-  let name = element.getAttribute("name") || tagName;
+  // Control-flow elements (if/else/repeat) have no user-facing name; the Rust
+  // target serializes them as empty string. Fall back to the tag name only
+  // for non-control-flow elements (folder/file/extends/etc.) where the tag
+  // name is meaningful as a default.
+  const isControlFlow = ["if", "else", "repeat"].includes(tagName);
+  let name = element.getAttribute("name") || (isControlFlow ? "" : tagName);
 
   // Validate name for file/folder nodes to prevent path traversal
   // Skip validation for control structures (if/else/repeat) which use internal names
@@ -198,10 +203,26 @@ const parseNode = (element: Element, depth: number): SchemaNode => {
     name,
   };
 
-  // Get attributes
+  // Capture only attributes NOT mapped to dedicated SchemaNode fields, so
+  // that `attributes` carries unhandled extras for round-trip preservation
+  // without duplicating url/var/count/etc. This matches the Rust target
+  // (parse_element in src-tauri/src/schema.rs).
+  const HANDLED_ATTRS = new Set([
+    "name",
+    "url",
+    "var",
+    "count",
+    "as",
+    "generate",
+    "template",
+    "width",
+    "height",
+    "background",
+    "format",
+  ]);
   const attributes: Record<string, string> = {};
   for (const attr of element.attributes) {
-    if (attr.name !== "name") {
+    if (!HANDLED_ATTRS.has(attr.name)) {
       attributes[attr.name] = attr.value;
     }
   }

--- a/fixtures/schema-parse.json
+++ b/fixtures/schema-parse.json
@@ -1,0 +1,93 @@
+[
+  {
+    "name": "plain folder with one file",
+    "xml": "<folder name=\"root\"><file name=\"hello.txt\" /></folder>",
+    "expected": {
+      "root": {
+        "type": "folder",
+        "name": "root",
+        "children": [
+          { "type": "file", "name": "hello.txt" }
+        ]
+      },
+      "stats": { "folders": 1, "files": 1, "downloads": 0, "generated": 0 }
+    }
+  },
+  {
+    "name": "nested folders",
+    "xml": "<folder name=\"root\"><folder name=\"src\"><file name=\"index.ts\" /></folder><folder name=\"docs\" /></folder>",
+    "expected": {
+      "root": {
+        "type": "folder",
+        "name": "root",
+        "children": [
+          {
+            "type": "folder",
+            "name": "src",
+            "children": [{ "type": "file", "name": "index.ts" }]
+          },
+          { "type": "folder", "name": "docs" }
+        ]
+      },
+      "stats": { "folders": 3, "files": 1, "downloads": 0, "generated": 0 }
+    }
+  },
+  {
+    "name": "file with url (download)",
+    "xml": "<folder name=\"root\"><file name=\"logo.png\" url=\"https://example.com/logo.png\" /></folder>",
+    "expected": {
+      "root": {
+        "type": "folder",
+        "name": "root",
+        "children": [
+          { "type": "file", "name": "logo.png", "url": "https://example.com/logo.png" }
+        ]
+      },
+      "stats": { "folders": 1, "files": 1, "downloads": 1, "generated": 0 }
+    }
+  },
+  {
+    "name": "if/else block",
+    "xml": "<folder name=\"root\"><if var=\"FLAG\"><file name=\"yes.txt\" /></if><else><file name=\"no.txt\" /></else></folder>",
+    "expected": {
+      "root": {
+        "type": "folder",
+        "name": "root",
+        "children": [
+          {
+            "type": "if",
+            "name": "",
+            "children": [{ "type": "file", "name": "yes.txt" }],
+            "condition_var": "FLAG"
+          },
+          {
+            "type": "else",
+            "name": "",
+            "children": [{ "type": "file", "name": "no.txt" }]
+          }
+        ]
+      },
+      "stats": { "folders": 1, "files": 2, "downloads": 0, "generated": 0 }
+    }
+  },
+  {
+    "name": "repeat block",
+    "xml": "<folder name=\"root\"><repeat count=\"3\" as=\"i\"><file name=\"item-%i%.txt\" /></repeat></folder>",
+    "expected": {
+      "root": {
+        "type": "folder",
+        "name": "root",
+        "children": [
+          {
+            "type": "repeat",
+            "name": "",
+            "children": [{ "type": "file", "name": "item-%i%.txt" }],
+            "repeat_count": "3",
+            "repeat_as": "i"
+          }
+        ]
+      },
+      "stats": { "folders": 1, "files": 1, "downloads": 0, "generated": 0 }
+    }
+  }
+]


### PR DESCRIPTION
Rescopes #96. The original premise — regex parser, fail loud on CDATA / namespaces — was wrong: the web target uses `DOMParser`, which handles those constructs fine. The actual cross-target risk is silent `SchemaTree` divergence between web DOMParser and Rust `quick_xml`. Extends the ADR-0002 golden-vector contract to cover parsing.

## What

- `fixtures/schema-parse.json` — `[{ name, xml, expected }]`. Each target parses the XML, serializes the resulting `SchemaTree` to JSON, asserts equality against the committed expected tree.
- Rust contract (`schema.rs::test_schema_parse_matches_golden_contract`): `parse_xml_schema → serde_json::to_value → assert_eq`.
- TS contract (`src/contract/schema-parse.contract.test.ts`): `parseSchema` (web DOMParser path) → JSON round-trip → `deepEqual`.

## Real divergences surfaced + fixed

The contract caught two cross-target parser bugs the day it landed:

1. **`attributes` capture.** Web stored *all* non-`name` XML attributes in `node.attributes`, including ones already mapped to dedicated fields (`url`, `var`, `count`, …) — duplicated state, double-emit on export. Rust captures only unhandled attrs. Fix: web now skips the handled set when populating `node.attributes`.
2. **Control-flow element name.** Web fell back to the tag name when no `name` attribute was present, so `<if>` / `<else>` / `<repeat>` parsed with `name: "if" / "else" / "repeat"`. Rust serializes those as empty string. Fix: control-flow elements default to `""`; the tag-name fallback stays for `folder` / `file` / `extends`.

## Cases

Plain folder with file; nested folders; file with `url` (download); `if`/`else` block; `repeat` block.

## Verification

- Full TS suite **375/375** (`tsc --noEmit` clean).
- Full Rust suite **252/252**.

Closes #96