### PR TITLE
Golden vectors for divergent repeat edges; align contract surrogates

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -19,6 +19,10 @@ _Avoid_: var, key, delimited name.
 The delimited `%NAME%` form of a Variable name as it appears in schema text and on the Tauri IPC wire. Produced only at outbound edges from a Variable name; never the stored or internal form.
 _Avoid_: variable placeholder, %-name, wrapped name.
 
+**Plan**:
+The tree of resolved nodes a Target produces by expanding a Schema with a complete Variable map (built-ins included): resolved names, rendered inline content, with IO-dependent content deferred as instructions (download, generate). Pure and deterministic — the unit the golden-vector contract pins. Creating a structure executes a Plan; diff preview compares a Plan against disk.
+_Avoid_: preview tree, expanded tree, diff tree.
+
 **Target**:
 A platform implementation that turns a Schema into a structure: the native target (Rust backend, via Tauri) and the web target (TypeScript, in-browser). Both are permanently supported.
 _Avoid_: platform, mode, backend.
@@ -32,6 +36,7 @@ _Avoid_: feature flag, permission.
 - A **Schema** contains zero or more **Variable**s.
 - A **Variable** has exactly one **Variable name** (clean, canonical).
 - A **Variable token** is derived from a **Variable name** at an outbound edge (IPC to the Rust backend, or template-substitution scan); converting back (strip delimiters) is idempotent.
+- A **Target** expands a **Schema** plus complete **Variable** values into a **Plan**; execution (create) and diff preview are thin consumers of the Plan.
 - Both **Target**s must produce identical results for the shared semantic core (substitution, transforms, templating, schema-structure semantics); they may differ only where one lacks a **Capability**, and there the lacking Target fails loudly.
 
 ## Example dialogue

--- a/apps/desktop/src-tauri/src/diff_preview.rs
+++ b/apps/desktop/src-tauri/src/diff_preview.rs
@@ -9,6 +9,7 @@ use std::path::PathBuf;
 
 use crate::schema::SchemaNode;
 use crate::schema::SchemaTree;
+use crate::structure_creator::MAX_REPEAT_COUNT;
 use crate::transforms::substitute_variables;
 use crate::types::{
     DiffAction, DiffHunk, DiffLine, DiffLineType, DiffNode, DiffNodeType, DiffResult, DiffSummary,
@@ -22,8 +23,6 @@ use crate::types::{
 const MAX_DIFF_CONTENT_SIZE: usize = 50000;
 /// Maximum number of lines to show in diff
 const MAX_DIFF_LINES: usize = 1000;
-/// Maximum iterations for repeat blocks in diff preview
-const MAX_REPEAT_ITERATIONS: usize = 100;
 /// Maximum characters to show for condition values in if block names
 const MAX_CONDITION_DISPLAY_LEN: usize = 20;
 /// Truncated display length (leaving room for "...")
@@ -253,29 +252,48 @@ fn generate_diff_node(
             return Ok(None);
         }
         "repeat" => {
-            // Expand repeat blocks
+            // Expand repeat blocks. Edge semantics follow the Plan spec
+            // (ADR-0004, create-walker semantics): missing count defaults to
+            // 1; invalid, negative, or above-maximum counts and invalid
+            // iteration-variable names warn loudly and skip the block.
+            let as_var = node.repeat_as.as_deref().unwrap_or("i");
+            let first_char = as_var.chars().next();
+            if as_var.is_empty()
+                || !as_var.chars().all(|c| c.is_alphanumeric() || c == '_')
+                || first_char.map_or(false, |c| c.is_ascii_digit())
+            {
+                summary
+                    .warnings
+                    .push(format!("Invalid repeat variable name: '{}'", as_var));
+                return Ok(None);
+            }
+
             let count_str = node.repeat_count.as_deref().unwrap_or("1");
             let resolved_count_str = substitute_variables(count_str, variables);
-            let count = match resolved_count_str.parse::<usize>() {
-                Ok(n) => {
-                    if n > MAX_REPEAT_ITERATIONS {
-                        summary.warnings.push(format!(
-                            "Repeat count {} exceeds maximum ({}), clamped to {}",
-                            n, MAX_REPEAT_ITERATIONS, MAX_REPEAT_ITERATIONS
-                        ));
-                    }
-                    n.min(MAX_REPEAT_ITERATIONS)
+            let count: usize = match resolved_count_str.trim().parse::<i64>() {
+                Ok(n) if n < 0 => {
+                    summary.warnings.push(format!(
+                        "Repeat count cannot be negative: '{}'",
+                        resolved_count_str
+                    ));
+                    return Ok(None);
                 }
+                Ok(n) if n as u64 > MAX_REPEAT_COUNT as u64 => {
+                    summary.warnings.push(format!(
+                        "Repeat count '{}' exceeds maximum of {}",
+                        n, MAX_REPEAT_COUNT
+                    ));
+                    return Ok(None);
+                }
+                Ok(n) => n as usize,
                 Err(_) => {
                     summary.warnings.push(format!(
-                        "Invalid repeat count '{}' (resolved from '{}'), defaulting to 1",
+                        "Invalid repeat count: '{}' (resolved from '{}')",
                         resolved_count_str, count_str
                     ));
-                    1
+                    return Ok(None);
                 }
             };
-
-            let as_var = node.repeat_as.as_deref().unwrap_or("i");
             let mut all_children = Vec::new();
 
             for i in 0..count {

--- a/apps/desktop/src-tauri/src/structure_creator.rs
+++ b/apps/desktop/src-tauri/src/structure_creator.rs
@@ -1604,6 +1604,8 @@ mod tests {
             variables: HashMap<String, String>,
             #[serde(rename = "expectedPaths")]
             expected_paths: Vec<String>,
+            #[serde(rename = "expectedErrors", default)]
+            expected_errors: usize,
         }
 
         fn collect_paths(node: &crate::types::DiffNode, prefix: &str, out: &mut Vec<String>) {
@@ -1653,6 +1655,14 @@ mod tests {
                 paths, expected,
                 "case '{}': paths mismatch",
                 case.name
+            );
+
+            assert_eq!(
+                result.summary.warnings.len(),
+                case.expected_errors,
+                "case '{}': loud-error count mismatch (warnings: {:?})",
+                case.name,
+                result.summary.warnings
             );
         }
     }

--- a/apps/desktop/src/contract/schema-structure.contract.test.ts
+++ b/apps/desktop/src/contract/schema-structure.contract.test.ts
@@ -2,19 +2,21 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, it, expect } from "vitest";
 import type { SchemaTree } from "@structure-creator/shared";
-import { expandTreeToPaths } from "../lib/adapters/web/expand-tree";
+import { expandTree } from "../lib/adapters/web/expand-tree";
 
 /**
- * Golden-vector contract (ADR-0002). The schema-structure fixtures pin
- * structural semantics (variable substitution in names, repeat expansion,
- * condition evaluation) across targets, consumed by both this web TS suite
- * (via `expandTreeToPaths`) and the Rust suite (via `generate_diff_preview`).
+ * Golden-vector contract (ADR-0002, ADR-0004). The schema-structure fixtures
+ * pin structural semantics (variable substitution in names, repeat expansion,
+ * condition evaluation, loud-error edges) across targets, consumed by both
+ * this web TS suite (via `expandTree`) and the Rust suite (via
+ * `generate_diff_preview`).
  */
 interface SchemaStructureCase {
   name: string;
   tree: SchemaTree;
   variables: Record<string, string>;
   expectedPaths: string[];
+  expectedErrors?: number;
 }
 
 const fixturePath = resolve(
@@ -32,10 +34,12 @@ describe("schema-structure golden-vector contract", () => {
 
   it.each(cases)(
     "$name",
-    ({ tree, variables, expectedPaths }) => {
-      const got = [...expandTreeToPaths(tree, variables)].sort();
+    ({ tree, variables, expectedPaths, expectedErrors }) => {
+      const { paths, errors } = expandTree(tree, variables);
+      const got = [...paths].sort();
       const expected = [...expectedPaths].sort();
       expect(got).toEqual(expected);
+      expect(errors.length).toBe(expectedErrors ?? 0);
     }
   );
 });

--- a/apps/desktop/src/lib/adapters/web/expand-tree.ts
+++ b/apps/desktop/src/lib/adapters/web/expand-tree.ts
@@ -1,44 +1,60 @@
 import type { SchemaNode, SchemaTree } from "@structure-creator/shared";
 import { substituteVariables } from "./transforms";
+import { MAX_REPEAT_COUNT } from "./constants";
 
 /**
  * Pure tree expander: given a parsed schema and variable map, return the
  * relative paths (folders + files) that would result from creating the
- * structure. No filesystem access; mirrors the planning semantics used by
- * the Rust target's `generate_diff_preview` so the golden-vector contract
- * (ADR-0002, issue #101) can compare the two.
+ * structure, plus any loud errors. No filesystem access; mirrors the Plan
+ * semantics pinned by the golden-vector contract (ADR-0002, ADR-0004) so
+ * the two targets can be compared.
  *
  * Supports: folder, file, variable substitution in names, `<if var="X">`
  * conditional evaluation (truthy = non-empty and not "false"/"0"), `<else>`
  * sibling of the immediately preceding `<if>`, and `<repeat count as>`
- * iteration with the iteration variable available to children.
+ * iteration with 0-indexed (`%i%`) and 1-indexed (`%i_1%`) iteration
+ * variables available to children.
+ *
+ * Repeat edge semantics (ADR-0004, create-walker spec): missing count
+ * defaults to 1; negative, non-numeric, or above-maximum counts and invalid
+ * iteration-variable names produce a loud error and skip the block.
  */
+export interface ExpandResult {
+  paths: string[];
+  errors: string[];
+}
+
+export const expandTree = (
+  tree: SchemaTree,
+  variables: Record<string, string>
+): ExpandResult => {
+  const result: ExpandResult = { paths: [], errors: [] };
+  walk(tree.root, "", result, variables);
+  return result;
+};
+
 export const expandTreeToPaths = (
   tree: SchemaTree,
   variables: Record<string, string>
-): string[] => {
-  const paths: string[] = [];
-  walk(tree.root, "", paths, variables);
-  return paths;
-};
+): string[] => expandTree(tree, variables).paths;
 
 const walk = (
   node: SchemaNode,
   prefix: string,
-  paths: string[],
+  result: ExpandResult,
   variables: Record<string, string>
 ): void => {
   const name = substituteVariables(node.name, variables);
   const path = prefix ? `${prefix}/${name}` : name;
 
   if (node.type === "folder") {
-    paths.push(path);
-    walkChildren(node.children ?? [], path, paths, variables);
+    result.paths.push(path);
+    walkChildren(node.children ?? [], path, result, variables);
     return;
   }
 
   if (node.type === "file") {
-    paths.push(path);
+    result.paths.push(path);
     return;
   }
 };
@@ -46,7 +62,7 @@ const walk = (
 const walkChildren = (
   children: SchemaNode[],
   prefix: string,
-  paths: string[],
+  result: ExpandResult,
   variables: Record<string, string>
 ): void => {
   // Track the result of the most recent `<if>` so a sibling `<else>` knows
@@ -58,37 +74,74 @@ const walkChildren = (
       const truthy = isTruthy(child.condition_var, variables);
       lastIfWasTrue = truthy;
       if (truthy) {
-        walkChildren(child.children ?? [], prefix, paths, variables);
+        walkChildren(child.children ?? [], prefix, result, variables);
       }
       continue;
     }
 
     if (child.type === "else") {
       if (lastIfWasTrue === false) {
-        walkChildren(child.children ?? [], prefix, paths, variables);
+        walkChildren(child.children ?? [], prefix, result, variables);
       }
       lastIfWasTrue = null;
       continue;
     }
 
     if (child.type === "repeat") {
-      const count = parseRepeatCount(child.repeat_count, variables);
-      const iterName = child.repeat_as ?? "i";
-      for (let i = 0; i < count; i++) {
-        const scoped: Record<string, string> = {
-          ...variables,
-          [`%${iterName}%`]: String(i),
-        };
-        walkChildren(child.children ?? [], prefix, paths, scoped);
-      }
+      walkRepeat(child, prefix, result, variables);
       lastIfWasTrue = null;
       continue;
     }
 
-    walk(child, prefix, paths, variables);
+    walk(child, prefix, result, variables);
     lastIfWasTrue = null;
   }
 };
+
+const walkRepeat = (
+  node: SchemaNode,
+  prefix: string,
+  result: ExpandResult,
+  variables: Record<string, string>
+): void => {
+  const iterName = node.repeat_as ?? "i";
+  if (!isValidIterationName(iterName)) {
+    result.errors.push(`Invalid repeat variable name: '${iterName}'`);
+    return;
+  }
+
+  const raw = node.repeat_count ?? "1";
+  const substituted = substituteVariables(raw, variables);
+  const count = Number.parseInt(substituted.trim(), 10);
+  if (!Number.isFinite(count) || String(count) !== substituted.trim()) {
+    result.errors.push(`Invalid repeat count: '${substituted}'`);
+    return;
+  }
+  if (count < 0) {
+    result.errors.push(`Repeat count cannot be negative: '${substituted}'`);
+    return;
+  }
+  if (count > MAX_REPEAT_COUNT) {
+    result.errors.push(
+      `Repeat count '${count}' exceeds maximum of ${MAX_REPEAT_COUNT}`
+    );
+    return;
+  }
+
+  for (let i = 0; i < count; i++) {
+    const scoped: Record<string, string> = {
+      ...variables,
+      [`%${iterName}%`]: String(i),
+      [`%${iterName}_1%`]: String(i + 1),
+    };
+    walkChildren(node.children ?? [], prefix, result, scoped);
+  }
+};
+
+const isValidIterationName = (name: string): boolean =>
+  name.length > 0 &&
+  !/^\d/.test(name) &&
+  [...name].every((c) => /[a-zA-Z0-9_]/.test(c));
 
 const isTruthy = (
   conditionVar: string | undefined,
@@ -99,15 +152,4 @@ const isTruthy = (
   if (value === undefined) return false;
   const trimmed = value.trim().toLowerCase();
   return trimmed !== "" && trimmed !== "false" && trimmed !== "0";
-};
-
-const parseRepeatCount = (
-  raw: string | undefined,
-  variables: Record<string, string>
-): number => {
-  if (!raw) return 0;
-  const substituted = substituteVariables(raw, variables);
-  const n = Number.parseInt(substituted, 10);
-  if (!Number.isFinite(n) || n < 0) return 0;
-  return n;
 };

--- a/docs/adr/0004-plan-module-per-target.md
+++ b/docs/adr/0004-plan-module-per-target.md
@@ -1,0 +1,31 @@
+---
+status: accepted
+---
+
+# One Plan module per Target; the parity contract pins production expansion
+
+## Context
+
+Schema-structure semantics (if/else evaluation, repeat expansion, substitution in names) were implemented five times: the Rust create walker (`structure_creator.rs`) and diff walker (`diff_preview.rs`), and three web walkers (`processNode`, `generateDiffNode`, `expand-tree.ts`). The golden-vector schema-structure contract (ADR-0002) was wired to the two surrogates — `diff_preview.rs` and `expand-tree.ts` — not to the code that ships. The walkers had already diverged: missing repeat count defaults to 1 in both production walkers but 0 in the contract surrogate; the repeat cap is 10000 (loud) in create but 100 (silent) in Rust diff; `%i_1%` and iteration-name validation exist only in the production walkers.
+
+## Decision
+
+Each Target gets one deep **Plan** module (see `CONTEXT.md`): `expand(tree, variables) → Plan`, pure and deterministic. The Plan is a tree of resolved nodes — names resolved, inline content fully rendered (templating then substitution), IO-dependent content deferred as `Download`/`Generate` instructions — annotated with provenance (if-branch taken, repeat iteration) for diff display. Create executes a Plan; diff preview compares a Plan against disk; dry-run prints a Plan. The golden-vector contract points at `expand` on both Targets — the shipping code, not surrogates. The TS module lives in `packages/shared`; the Rust module in `src-tauri`.
+
+Where the walkers disagreed, the Rust create walker's semantics win, pinned by new golden vectors: missing repeat count → 1, negative/invalid count → loud error, count > 10000 → loud error, both `%i%` and `%i_1%` injected, iteration-variable name validated. Rust diff's 100-iteration truncation becomes a display-only concern in the diff view, never Plan semantics.
+
+The caller supplies a complete variable map — built-in Variables (`%DATE%` etc.) are injected at the edge, keeping `expand` pure and contract-testable with fixed values. Post-create hooks are a native Capability and stay in the native executor, outside the Plan.
+
+## Considered options
+
+- **Keep surrogate walkers for the contract.** Rejected: the contract then certifies semantics production doesn't have (the missing-count divergence was live and undetected).
+- **Flat path-list Plan.** Rejected: the diff UI renders a tree with if/else decision annotations; a flat list loses that provenance or forces diff to keep its own walker. Contract fixtures still consume flat paths via a trivial `toPaths(plan)` helper.
+- **Structure-only Plan (content deferred).** Rejected: leaves the templating-then-substitution content ordering duplicated across create and diff walkers — half the win.
+- **Keep the 100-cap in diff semantics.** Rejected: preview and create would keep disagreeing about what will happen — the silent-divergence smell relocated, not removed.
+
+## Consequences
+
+- `expand-tree.ts`, the web diff walker (`generateDiffNode` family), and most of `diff_preview.rs` are deleted; `diff_preview.rs` shrinks to plan-vs-disk comparison.
+- New golden vectors cover the formerly divergent edges; they will fail against today's surrogates, which is the point.
+- Diff preview behaviour changes user-visibly on large repeats: full plan computed (loud error past 10000) with any truncation happening only in rendering.
+- Refines ADR-0002's wiring; the contract's schema-structure vectors become a spec of the Plan.

--- a/fixtures/schema-structure.json
+++ b/fixtures/schema-structure.json
@@ -125,5 +125,134 @@
     },
     "variables": { "%COUNT%": "2" },
     "expectedPaths": ["root", "root/x-0.txt", "root/x-1.txt"]
+  },
+  {
+    "name": "repeat with missing count defaults to one iteration",
+    "tree": {
+      "root": {
+        "type": "folder",
+        "name": "root",
+        "children": [
+          {
+            "type": "repeat",
+            "name": "",
+            "repeat_as": "i",
+            "children": [{ "type": "file", "name": "item-%i%.txt" }]
+          }
+        ]
+      },
+      "stats": { "folders": 0, "files": 0, "downloads": 0, "generated": 0 }
+    },
+    "variables": {},
+    "expectedPaths": ["root", "root/item-0.txt"]
+  },
+  {
+    "name": "repeat injects both 0-indexed and 1-indexed iteration variables",
+    "tree": {
+      "root": {
+        "type": "folder",
+        "name": "root",
+        "children": [
+          {
+            "type": "repeat",
+            "name": "",
+            "repeat_count": "2",
+            "repeat_as": "n",
+            "children": [{ "type": "file", "name": "item-%n%-of-%n_1%.txt" }]
+          }
+        ]
+      },
+      "stats": { "folders": 0, "files": 0, "downloads": 0, "generated": 0 }
+    },
+    "variables": {},
+    "expectedPaths": ["root", "root/item-0-of-1.txt", "root/item-1-of-2.txt"]
+  },
+  {
+    "name": "repeat with negative count errors loudly and skips the block",
+    "tree": {
+      "root": {
+        "type": "folder",
+        "name": "root",
+        "children": [
+          {
+            "type": "repeat",
+            "name": "",
+            "repeat_count": "-2",
+            "repeat_as": "i",
+            "children": [{ "type": "file", "name": "item-%i%.txt" }]
+          }
+        ]
+      },
+      "stats": { "folders": 0, "files": 0, "downloads": 0, "generated": 0 }
+    },
+    "variables": {},
+    "expectedPaths": ["root"],
+    "expectedErrors": 1
+  },
+  {
+    "name": "repeat with non-numeric count errors loudly and skips the block",
+    "tree": {
+      "root": {
+        "type": "folder",
+        "name": "root",
+        "children": [
+          {
+            "type": "repeat",
+            "name": "",
+            "repeat_count": "banana",
+            "repeat_as": "i",
+            "children": [{ "type": "file", "name": "item-%i%.txt" }]
+          }
+        ]
+      },
+      "stats": { "folders": 0, "files": 0, "downloads": 0, "generated": 0 }
+    },
+    "variables": {},
+    "expectedPaths": ["root"],
+    "expectedErrors": 1
+  },
+  {
+    "name": "repeat with count above maximum errors loudly and skips the block",
+    "tree": {
+      "root": {
+        "type": "folder",
+        "name": "root",
+        "children": [
+          {
+            "type": "repeat",
+            "name": "",
+            "repeat_count": "10001",
+            "repeat_as": "i",
+            "children": [{ "type": "file", "name": "item-%i%.txt" }]
+          }
+        ]
+      },
+      "stats": { "folders": 0, "files": 0, "downloads": 0, "generated": 0 }
+    },
+    "variables": {},
+    "expectedPaths": ["root"],
+    "expectedErrors": 1
+  },
+  {
+    "name": "repeat with invalid iteration variable name errors loudly and skips the block",
+    "tree": {
+      "root": {
+        "type": "folder",
+        "name": "root",
+        "children": [
+          {
+            "type": "repeat",
+            "name": "",
+            "repeat_count": "2",
+            "repeat_as": "1bad",
+            "children": [{ "type": "file", "name": "item.txt" }]
+          }
+        ]
+      },
+      "stats": { "folders": 0, "files": 0, "downloads": 0, "generated": 0 }
+    },
+    "variables": {},
+    "expectedPaths": ["root"],
+    "expectedErrors": 1
   }
 ]


### PR DESCRIPTION
Closes #122. First slice of the Plan-module migration (ADR-0004, included here along with the new **Plan** term in CONTEXT.md).

## What

- Six new schema-structure golden vectors pinning the agreed repeat spec: missing count → 1, negative / non-numeric / above-10000 counts → loud error + block skipped, `%i%` + `%i_1%` both injected, iteration-variable names validated.
- Fixture format gains optional `expectedErrors` (count of loud errors); both contract consumers assert it.
- Web surrogate (`expand-tree.ts`): new `expandTree` returning `{paths, errors}` with the edge semantics; `expandTreeToPaths` kept as a thin wrapper.
- Rust surrogate (`diff_preview.rs`): silent 100-iteration clamp and invalid-count-defaults-to-1 removed — now validates the iteration name, parses as i64, and warns loudly + skips at the shared `MAX_REPEAT_COUNT` (10000), matching the create walker.

## Why

The contract previously certified semantics production doesn't have (surrogate defaulted missing count to 0 where both production walkers default to 1; Rust diff silently clamped at 100 where create errors loudly at 10000). This slice makes the contract honest before slices #123–#126 replace the surrogates with real Plan modules.

## Tests

- Rust: 252 + 49 + 46 pass, including all five golden-contract tests
- TS: 381 pass (13 schema-structure contract cases)
- tsc clean