### PR TITLE
Rust Plan module: pure expand, create executes the Plan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ coverage/
 *.tmp
 *.temp
 .cache/
+.claude/worktrees/

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@
 // Domain modules (unchanged)
 pub mod database;
 pub mod generators;
+pub mod plan;
 pub mod plugins;
 pub mod schema;
 pub mod team_library;

--- a/apps/desktop/src-tauri/src/plan.rs
+++ b/apps/desktop/src-tauri/src/plan.rs
@@ -1,0 +1,621 @@
+//! Pure Plan expansion (ADR-0004).
+//!
+//! Turns a Schema tree plus a complete variable map into the Plan: the tree
+//! of resolved nodes that structure creation executes and diff preview
+//! compares against disk. No filesystem, network, or clock access — built-in
+//! variables are injected by the caller.
+
+use std::collections::HashMap;
+
+use crate::schema::{SchemaNode, SchemaTree};
+use crate::templating;
+use crate::transforms::substitute_variables;
+
+/// Maximum allowed repeat count to prevent accidental resource exhaustion
+pub const MAX_REPEAT_COUNT: usize = 10000;
+
+/// How a planned file gets its bytes.
+#[derive(Debug, Clone, PartialEq)]
+pub enum PlanContent {
+    /// Fully rendered content (templating then substitution already applied).
+    /// `had_content` records whether the schema node carried any content at
+    /// all, which execution logging distinguishes from rendered-empty.
+    Inline { text: String, had_content: bool },
+    /// Download at execution time. Downloaded bytes are still variable-
+    /// substituted / binary-processed by the executor (impure input).
+    Download { url: String },
+    /// Produce via a generator; the schema node carries the generator config.
+    Generate { node: SchemaNode },
+}
+
+/// Which decisions put a node in the Plan (diff display provenance).
+#[derive(Debug, Clone, PartialEq)]
+pub enum Provenance {
+    If { var: String },
+    Else { var: String },
+    Repeat {
+        var: String,
+        iteration: usize,
+        count: usize,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum PlanKind {
+    Folder { children: Vec<PlanNode> },
+    File { content: PlanContent },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PlanNode {
+    /// Resolved (variable-substituted) name.
+    pub name: String,
+    pub kind: PlanKind,
+    /// Decision chain from the schema root down to this node.
+    pub provenance: Vec<Provenance>,
+}
+
+/// Expansion-time facts the executor turns into log entries.
+#[derive(Debug, Clone, PartialEq)]
+pub enum PlanNote {
+    /// Loud error: the offending block was skipped.
+    Error { message: String, details: String },
+    Warning {
+        message: String,
+        details: Option<String>,
+    },
+    Info {
+        message: String,
+        details: Option<String>,
+    },
+    /// A repeat block expanded; the executor phrases this per dry-run mode.
+    RepeatExpanded { count: usize, as_var: String },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Plan {
+    /// Top-level resolved nodes. A schema whose root is a folder or file has
+    /// exactly one; a root-level if/repeat can yield zero or many.
+    pub roots: Vec<PlanNode>,
+    pub notes: Vec<PlanNote>,
+}
+
+impl Plan {
+    pub fn error_count(&self) -> usize {
+        self.notes
+            .iter()
+            .filter(|n| matches!(n, PlanNote::Error { .. }))
+            .count()
+    }
+}
+
+/// Expand a Schema tree into a Plan. `variables` must be complete (built-ins
+/// already injected); keys are variable tokens (`%NAME%`).
+pub fn expand(tree: &SchemaTree, variables: &HashMap<String, String>) -> Plan {
+    let mut notes = Vec::new();
+    let mut roots = Vec::new();
+    expand_children(
+        std::slice::from_ref(&tree.root),
+        variables,
+        &[],
+        &mut roots,
+        &mut notes,
+    );
+    Plan { roots, notes }
+}
+
+/// Flatten a Plan to relative slash-joined paths (the contract-test surface).
+pub fn to_paths(plan: &Plan) -> Vec<String> {
+    let mut out = Vec::new();
+    for root in &plan.roots {
+        collect_paths(root, "", &mut out);
+    }
+    out
+}
+
+fn collect_paths(node: &PlanNode, prefix: &str, out: &mut Vec<String>) {
+    let path = if prefix.is_empty() {
+        node.name.clone()
+    } else {
+        format!("{}/{}", prefix, node.name)
+    };
+    out.push(path.clone());
+    if let PlanKind::Folder { children } = &node.kind {
+        for child in children {
+            collect_paths(child, &path, out);
+        }
+    }
+}
+
+/// Check if a string value is "truthy".
+/// Empty strings and common falsy values ("false", "0", "no") are considered false
+fn is_truthy(value: &str) -> bool {
+    if value.is_empty() {
+        return false;
+    }
+    !matches!(
+        value.to_lowercase().as_str(),
+        "false" | "0" | "no" | "off" | "disabled"
+    )
+}
+
+fn evaluate_if_condition(node: &SchemaNode, variables: &HashMap<String, String>) -> bool {
+    if let Some(var_name) = &node.condition_var {
+        let lookup_key = format!("%{}%", var_name);
+        variables
+            .get(&lookup_key)
+            .map(|v| is_truthy(v))
+            .unwrap_or(false)
+    } else {
+        false
+    }
+}
+
+fn expand_children(
+    children: &[SchemaNode],
+    variables: &HashMap<String, String>,
+    provenance: &[Provenance],
+    out: &mut Vec<PlanNode>,
+    notes: &mut Vec<PlanNote>,
+) {
+    // Track the most recent `if` result so a sibling `else` knows whether to
+    // emit. Any other node type breaks the chain.
+    let mut last_if: Option<(String, bool)> = None;
+
+    for child in children {
+        match child.node_type.as_str() {
+            "if" => {
+                let var = child.condition_var.clone().unwrap_or_default();
+                let met = evaluate_if_condition(child, variables);
+                if met {
+                    if let Some(kids) = &child.children {
+                        let chain = with_provenance(provenance, Provenance::If { var: var.clone() });
+                        expand_children(kids, variables, &chain, out, notes);
+                    }
+                }
+                last_if = Some((var, met));
+            }
+            "else" => match last_if.take() {
+                Some((var, was_true)) => {
+                    if !was_true {
+                        if let Some(kids) = &child.children {
+                            let chain = with_provenance(provenance, Provenance::Else { var });
+                            expand_children(kids, variables, &chain, out, notes);
+                        }
+                    }
+                }
+                None => {
+                    notes.push(PlanNote::Warning {
+                        message: "Skipped orphaned else block (no preceding if)".to_string(),
+                        details: Some(
+                            "Else blocks must immediately follow an if block".to_string(),
+                        ),
+                    });
+                }
+            },
+            "repeat" => {
+                expand_repeat(child, variables, provenance, out, notes);
+                last_if = None;
+            }
+            _ => {
+                if let Some(node) = expand_node(child, variables, provenance, notes) {
+                    out.push(node);
+                }
+                last_if = None;
+            }
+        }
+    }
+}
+
+fn expand_repeat(
+    node: &SchemaNode,
+    variables: &HashMap<String, String>,
+    provenance: &[Provenance],
+    out: &mut Vec<PlanNode>,
+    notes: &mut Vec<PlanNote>,
+) {
+    let count_str = node.repeat_count.as_deref().unwrap_or("1");
+    let as_var = node.repeat_as.as_deref().unwrap_or("i");
+
+    // Validate 'as' variable name: non-empty, alphanumeric/underscore only,
+    // must not start with a digit.
+    let first_char = as_var.chars().next();
+    if as_var.is_empty()
+        || !as_var.chars().all(|c| c.is_alphanumeric() || c == '_')
+        || first_char.map_or(false, |c| c.is_ascii_digit())
+    {
+        notes.push(PlanNote::Error {
+            message: format!("Invalid repeat variable name: '{}'", as_var),
+            details: "Variable name must be non-empty, start with a letter or underscore, and contain only alphanumeric characters or underscores".to_string(),
+        });
+        return;
+    }
+
+    // Since %var_1% is the 1-indexed version, %n_1% would create %n_1% and %n_1_1%
+    if as_var.ends_with("_1") {
+        notes.push(PlanNote::Warning {
+            message: format!(
+                "Variable name '{}' ends with '_1' which may be confusing",
+                as_var
+            ),
+            details: Some(format!(
+                "The 1-indexed variable will be '%{}_1%'. Consider using a different name.",
+                as_var
+            )),
+        });
+    }
+
+    let resolved = substitute_variables(count_str, variables);
+    let count: usize = match resolved.trim().parse::<i64>() {
+        Ok(n) if n < 0 => {
+            notes.push(PlanNote::Error {
+                message: format!("Repeat count cannot be negative: '{}'", resolved),
+                details: format!(
+                    "Count must be a non-negative integer (resolved from '{}')",
+                    count_str
+                ),
+            });
+            return;
+        }
+        Ok(n) if n as u64 > MAX_REPEAT_COUNT as u64 => {
+            notes.push(PlanNote::Error {
+                message: format!("Repeat count '{}' exceeds maximum of {}", n, MAX_REPEAT_COUNT),
+                details: "Consider reducing the count or splitting into multiple repeat blocks"
+                    .to_string(),
+            });
+            return;
+        }
+        Ok(n) => n as usize,
+        Err(_) => {
+            notes.push(PlanNote::Error {
+                message: format!("Invalid repeat count: '{}'", resolved),
+                details: format!(
+                    "Count must be a non-negative integer (resolved from '{}')",
+                    count_str
+                ),
+            });
+            return;
+        }
+    };
+
+    if count == 0 {
+        let details = if count_str == "0" {
+            "Count is explicitly set to 0".to_string()
+        } else {
+            format!("Count '{}' resolved to 0", count_str)
+        };
+        notes.push(PlanNote::Info {
+            message: "Skipping repeat block (count is 0)".to_string(),
+            details: Some(details),
+        });
+        return;
+    }
+
+    notes.push(PlanNote::RepeatExpanded {
+        count,
+        as_var: as_var.to_string(),
+    });
+
+    if let Some(children) = &node.children {
+        let mut scoped_vars = variables.clone();
+        let var_0_key = format!("%{}%", as_var);
+        let var_1_key = format!("%{}_1%", as_var);
+
+        for i in 0..count {
+            scoped_vars.insert(var_0_key.clone(), i.to_string());
+            scoped_vars.insert(var_1_key.clone(), (i + 1).to_string());
+            let chain = with_provenance(
+                provenance,
+                Provenance::Repeat {
+                    var: as_var.to_string(),
+                    iteration: i,
+                    count,
+                },
+            );
+            expand_children(children, &scoped_vars, &chain, out, notes);
+        }
+    }
+}
+
+fn expand_node(
+    node: &SchemaNode,
+    variables: &HashMap<String, String>,
+    provenance: &[Provenance],
+    notes: &mut Vec<PlanNote>,
+) -> Option<PlanNode> {
+    let name = substitute_variables(&node.name, variables);
+
+    match node.node_type.as_str() {
+        "folder" => {
+            let mut children = Vec::new();
+            if let Some(kids) = &node.children {
+                expand_children(kids, variables, &[], &mut children, notes);
+            }
+            Some(PlanNode {
+                name,
+                kind: PlanKind::Folder { children },
+                provenance: provenance.to_vec(),
+            })
+        }
+        "file" => {
+            let content = if let Some(url) = &node.url {
+                PlanContent::Download { url: url.clone() }
+            } else if node.generate.is_some() {
+                PlanContent::Generate { node: node.clone() }
+            } else {
+                let had_content = node.content.is_some();
+                let raw = node.content.clone().unwrap_or_default();
+                let text = if node.template == Some(true) {
+                    match templating::process_template(&raw, variables) {
+                        Ok(processed) => substitute_variables(&processed, variables),
+                        Err(e) => {
+                            notes.push(PlanNote::Warning {
+                                message: format!("Template error in {}", name),
+                                details: Some(e.to_string()),
+                            });
+                            substitute_variables(&raw, variables)
+                        }
+                    }
+                } else {
+                    substitute_variables(&raw, variables)
+                };
+                PlanContent::Inline { text, had_content }
+            };
+            Some(PlanNode {
+                name,
+                kind: PlanKind::File { content },
+                provenance: provenance.to_vec(),
+            })
+        }
+        _ => None,
+    }
+}
+
+fn with_provenance(chain: &[Provenance], next: Provenance) -> Vec<Provenance> {
+    let mut out = chain.to_vec();
+    out.push(next);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::{SchemaNode, SchemaStats, SchemaTree};
+
+    fn tree(root: SchemaNode) -> SchemaTree {
+        SchemaTree {
+            root,
+            stats: SchemaStats::default(),
+            hooks: None,
+            variable_definitions: None,
+        }
+    }
+
+    fn folder(name: &str, children: Vec<SchemaNode>) -> SchemaNode {
+        SchemaNode {
+            name: name.to_string(),
+            node_type: "folder".to_string(),
+            children: Some(children),
+            ..Default::default()
+        }
+    }
+
+    fn file(name: &str) -> SchemaNode {
+        SchemaNode {
+            name: name.to_string(),
+            node_type: "file".to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn vars(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn resolves_names_and_renders_inline_content() {
+        let mut f = file("%NAME%.txt");
+        f.content = Some("Hello %NAME%".to_string());
+        let t = tree(folder("%NAME%", vec![f]));
+        let plan = expand(&t, &vars(&[("%NAME%", "demo")]));
+
+        assert_eq!(to_paths(&plan), vec!["demo", "demo/demo.txt"]);
+        let root = &plan.roots[0];
+        let PlanKind::Folder { children } = &root.kind else {
+            panic!("root should be folder")
+        };
+        let PlanKind::File { content } = &children[0].kind else {
+            panic!("child should be file")
+        };
+        assert_eq!(
+            content,
+            &PlanContent::Inline {
+                text: "Hello demo".to_string(),
+                had_content: true
+            }
+        );
+    }
+
+    #[test]
+    fn template_content_is_processed_then_substituted() {
+        let mut f = file("out.txt");
+        f.content = Some("{{if FLAG}}on %NAME%{{endif}}".to_string());
+        f.template = Some(true);
+        let t = tree(folder("root", vec![f]));
+        let plan = expand(&t, &vars(&[("%FLAG%", "true"), ("%NAME%", "x")]));
+
+        let PlanKind::Folder { children } = &plan.roots[0].kind else {
+            panic!()
+        };
+        let PlanKind::File { content } = &children[0].kind else {
+            panic!()
+        };
+        let PlanContent::Inline { text, .. } = content else {
+            panic!()
+        };
+        assert_eq!(text, "on x");
+    }
+
+    #[test]
+    fn url_becomes_download_instruction() {
+        let mut f = file("logo.png");
+        f.url = Some("https://example.com/logo.png".to_string());
+        let t = tree(folder("root", vec![f]));
+        let plan = expand(&t, &HashMap::new());
+
+        let PlanKind::Folder { children } = &plan.roots[0].kind else {
+            panic!()
+        };
+        assert!(matches!(
+            &children[0].kind,
+            PlanKind::File {
+                content: PlanContent::Download { url }
+            } if url == "https://example.com/logo.png"
+        ));
+    }
+
+    #[test]
+    fn generator_becomes_generate_instruction() {
+        let mut f = file("db.sqlite");
+        f.generate = Some("sqlite".to_string());
+        let t = tree(folder("root", vec![f]));
+        let plan = expand(&t, &HashMap::new());
+
+        let PlanKind::Folder { children } = &plan.roots[0].kind else {
+            panic!()
+        };
+        assert!(matches!(
+            &children[0].kind,
+            PlanKind::File {
+                content: PlanContent::Generate { .. }
+            }
+        ));
+    }
+
+    #[test]
+    fn if_else_selects_branch_and_records_provenance() {
+        let mut if_node = SchemaNode {
+            node_type: "if".to_string(),
+            condition_var: Some("FLAG".to_string()),
+            children: Some(vec![file("yes.txt")]),
+            ..Default::default()
+        };
+        if_node.name = String::new();
+        let else_node = SchemaNode {
+            node_type: "else".to_string(),
+            children: Some(vec![file("no.txt")]),
+            ..Default::default()
+        };
+        let t = tree(folder("root", vec![if_node, else_node]));
+
+        let taken = expand(&t, &vars(&[("%FLAG%", "yes")]));
+        assert_eq!(to_paths(&taken), vec!["root", "root/yes.txt"]);
+
+        let not_taken = expand(&t, &HashMap::new());
+        assert_eq!(to_paths(&not_taken), vec!["root", "root/no.txt"]);
+        let PlanKind::Folder { children } = &not_taken.roots[0].kind else {
+            panic!()
+        };
+        assert_eq!(
+            children[0].provenance,
+            vec![Provenance::Else {
+                var: "FLAG".to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn falsy_values_include_no_off_disabled() {
+        for falsy in ["no", "off", "disabled", "false", "0", ""] {
+            let if_node = SchemaNode {
+                node_type: "if".to_string(),
+                condition_var: Some("FLAG".to_string()),
+                children: Some(vec![file("yes.txt")]),
+                ..Default::default()
+            };
+            let t = tree(folder("root", vec![if_node]));
+            let plan = expand(&t, &vars(&[("%FLAG%", falsy)]));
+            assert_eq!(to_paths(&plan), vec!["root"], "'{}' should be falsy", falsy);
+        }
+    }
+
+    #[test]
+    fn repeat_expands_with_both_iteration_variables_and_provenance() {
+        let repeat = SchemaNode {
+            node_type: "repeat".to_string(),
+            repeat_count: Some("2".to_string()),
+            repeat_as: Some("n".to_string()),
+            children: Some(vec![file("item-%n%-of-%n_1%.txt")]),
+            ..Default::default()
+        };
+        let t = tree(folder("root", vec![repeat]));
+        let plan = expand(&t, &HashMap::new());
+
+        assert_eq!(
+            to_paths(&plan),
+            vec!["root", "root/item-0-of-1.txt", "root/item-1-of-2.txt"]
+        );
+        assert!(plan
+            .notes
+            .iter()
+            .any(|n| matches!(n, PlanNote::RepeatExpanded { count: 2, as_var } if as_var == "n")));
+        let PlanKind::Folder { children } = &plan.roots[0].kind else {
+            panic!()
+        };
+        assert_eq!(
+            children[1].provenance,
+            vec![Provenance::Repeat {
+                var: "n".to_string(),
+                iteration: 1,
+                count: 2
+            }]
+        );
+    }
+
+    #[test]
+    fn repeat_edge_errors_skip_block_loudly() {
+        for (count, expected_fragment) in [
+            ("-2", "cannot be negative"),
+            ("banana", "Invalid repeat count"),
+            ("10001", "exceeds maximum"),
+        ] {
+            let repeat = SchemaNode {
+                node_type: "repeat".to_string(),
+                repeat_count: Some(count.to_string()),
+                repeat_as: Some("i".to_string()),
+                children: Some(vec![file("item-%i%.txt")]),
+                ..Default::default()
+            };
+            let t = tree(folder("root", vec![repeat]));
+            let plan = expand(&t, &HashMap::new());
+            assert_eq!(to_paths(&plan), vec!["root"], "count '{}'", count);
+            assert_eq!(plan.error_count(), 1, "count '{}'", count);
+            assert!(
+                plan.notes.iter().any(|n| matches!(
+                    n,
+                    PlanNote::Error { message, .. } if message.contains(expected_fragment)
+                )),
+                "count '{}' should mention '{}'",
+                count,
+                expected_fragment
+            );
+        }
+    }
+
+    #[test]
+    fn expansion_is_deterministic() {
+        let repeat = SchemaNode {
+            node_type: "repeat".to_string(),
+            repeat_count: Some("3".to_string()),
+            repeat_as: Some("i".to_string()),
+            children: Some(vec![file("f-%i%.txt")]),
+            ..Default::default()
+        };
+        let t = tree(folder("root", vec![repeat]));
+        let v = vars(&[("%NAME%", "x")]);
+        assert_eq!(expand(&t, &v), expand(&t, &v));
+    }
+}

--- a/apps/desktop/src-tauri/src/schema.rs
+++ b/apps/desktop/src-tauri/src/schema.rs
@@ -7,7 +7,7 @@ use std::io::Read;
 /// Default condition variable name for if blocks without an explicit var attribute
 const DEFAULT_CONDITION_VAR: &str = "CONDITION";
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default, specta::Type)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default, specta::Type)]
 pub struct SchemaNode {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,

--- a/apps/desktop/src-tauri/src/structure_creator.rs
+++ b/apps/desktop/src-tauri/src/structure_creator.rs
@@ -12,31 +12,15 @@ use crate::file_processors::{
     process_sqlite_database,
 };
 use crate::generators;
-use crate::schema::{self, SchemaTree};
-use crate::templating;
+use crate::plan::{self, PlanContent, PlanKind, PlanNode, PlanNote};
+use crate::schema::SchemaTree;
 use crate::transforms::substitute_variables;
 use crate::types::{
     CreateResult, CreatedItem, HookResult, ItemType, LogEntry, ResultSummary, UndoResult,
     UndoSummary,
 };
 
-/// Maximum allowed repeat count to prevent accidental resource exhaustion
-pub const MAX_REPEAT_COUNT: usize = 10000;
-
-/// Helper to log a repeat-related error and increment error count
-fn log_repeat_error(
-    logs: &mut Vec<LogEntry>,
-    summary: &mut ResultSummary,
-    message: String,
-    details: String,
-) {
-    logs.push(LogEntry {
-        log_type: "error".to_string(),
-        message,
-        details: Some(details),
-    });
-    summary.errors += 1;
-}
+pub use crate::plan::MAX_REPEAT_COUNT;
 
 /// Create a folder/file structure from a schema tree
 pub fn create_structure_from_tree(
@@ -78,17 +62,60 @@ pub fn create_structure_from_tree(
         all_variables.insert(k.clone(), v.clone());
     }
 
-    // Create structure recursively
-    create_node(
-        &tree.root,
-        &base_path,
-        &all_variables,
-        dry_run,
-        overwrite,
-        &mut logs,
-        &mut summary,
-        &mut created_items,
-    )?;
+    // Expand the schema into a Plan (pure), then execute it
+    let structure_plan = plan::expand(tree, &all_variables);
+
+    for note in &structure_plan.notes {
+        match note {
+            PlanNote::Error { message, details } => {
+                summary.errors += 1;
+                logs.push(LogEntry {
+                    log_type: "error".to_string(),
+                    message: message.clone(),
+                    details: Some(details.clone()),
+                });
+            }
+            PlanNote::Warning { message, details } => {
+                logs.push(LogEntry {
+                    log_type: "warning".to_string(),
+                    message: message.clone(),
+                    details: details.clone(),
+                });
+            }
+            PlanNote::Info { message, details } => {
+                logs.push(LogEntry {
+                    log_type: "info".to_string(),
+                    message: message.clone(),
+                    details: details.clone(),
+                });
+            }
+            PlanNote::RepeatExpanded { count, as_var } => {
+                logs.push(LogEntry {
+                    log_type: "info".to_string(),
+                    message: format!(
+                        "{} {} times (as %{}%)",
+                        if dry_run { "Would repeat" } else { "Repeating" },
+                        count,
+                        as_var
+                    ),
+                    details: None,
+                });
+            }
+        }
+    }
+
+    for root in &structure_plan.roots {
+        execute_plan_node(
+            root,
+            &base_path,
+            &all_variables,
+            dry_run,
+            overwrite,
+            &mut logs,
+            &mut summary,
+            &mut created_items,
+        )?;
+    }
 
     // Execute post-create hooks if present and not in dry-run mode
     if let Some(ref hooks) = tree.hooks {
@@ -205,33 +232,9 @@ fn execute_hook(command: &str, working_dir: &PathBuf) -> HookResult {
     }
 }
 
-/// Check if a string value is "truthy"
-/// Empty strings and common falsy values ("false", "0", "no") are considered false
-fn is_truthy(value: &str) -> bool {
-    if value.is_empty() {
-        return false;
-    }
-    // Check for common falsy string values (case-insensitive)
-    !matches!(
-        value.to_lowercase().as_str(),
-        "false" | "0" | "no" | "off" | "disabled"
-    )
-}
-
-/// Evaluate if condition without side effects
-fn evaluate_if_condition(node: &schema::SchemaNode, variables: &HashMap<String, String>) -> bool {
-    if let Some(var_name) = &node.condition_var {
-        // Variables are stored with % wrapping (e.g., %NAME%), so wrap the var name
-        let lookup_key = format!("%{}%", var_name);
-        variables.get(&lookup_key).map(|v| is_truthy(v)).unwrap_or(false)
-    } else {
-        false
-    }
-}
-
-/// Process a list of child nodes, tracking if/else state between siblings
-fn process_children(
-    children: &[schema::SchemaNode],
+/// Execute a single Plan node against the filesystem.
+fn execute_plan_node(
+    node: &PlanNode,
     parent_path: &PathBuf,
     variables: &HashMap<String, String>,
     dry_run: bool,
@@ -240,272 +243,12 @@ fn process_children(
     summary: &mut ResultSummary,
     created_items: &mut Vec<CreatedItem>,
 ) -> Result<(), String> {
-    let mut child_last_if = None;
-    for child in children {
-        create_node_internal(
-            child,
-            parent_path,
-            variables,
-            dry_run,
-            overwrite,
-            logs,
-            summary,
-            created_items,
-            child_last_if,
-        )?;
-        // Track if results for else blocks
-        // Only if nodes followed immediately by else nodes form a valid if/else chain
-        // Any other node type (folder, file) breaks the chain
-        match child.node_type.as_str() {
-            "if" => child_last_if = Some(evaluate_if_condition(child, variables)),
-            "else" => child_last_if = None, // Break chain - only one else per if
-            _ => child_last_if = None,      // Non-conditional nodes break the if/else chain
-        }
-    }
-    Ok(())
-}
-
-fn create_node(
-    node: &schema::SchemaNode,
-    parent_path: &PathBuf,
-    variables: &HashMap<String, String>,
-    dry_run: bool,
-    overwrite: bool,
-    logs: &mut Vec<LogEntry>,
-    summary: &mut ResultSummary,
-    created_items: &mut Vec<CreatedItem>,
-) -> Result<(), String> {
-    create_node_internal(
-        node,
-        parent_path,
-        variables,
-        dry_run,
-        overwrite,
-        logs,
-        summary,
-        created_items,
-        None,
-    )
-}
-
-fn create_node_internal(
-    node: &schema::SchemaNode,
-    parent_path: &PathBuf,
-    variables: &HashMap<String, String>,
-    dry_run: bool,
-    overwrite: bool,
-    logs: &mut Vec<LogEntry>,
-    summary: &mut ResultSummary,
-    created_items: &mut Vec<CreatedItem>,
-    last_if_result: Option<bool>,
-) -> Result<(), String> {
-    // Handle conditional and repeat nodes (if/else/repeat)
-    match node.node_type.as_str() {
-        "if" => {
-            // Evaluate condition using shared helper
-            let condition_met = evaluate_if_condition(node, variables);
-
-            // Process children if condition is met
-            if condition_met {
-                if let Some(children) = &node.children {
-                    process_children(
-                        children,
-                        parent_path,
-                        variables,
-                        dry_run,
-                        overwrite,
-                        logs,
-                        summary,
-                        created_items,
-                    )?;
-                }
-            }
-
-            return Ok(());
-        }
-        "else" => {
-            // Execute else block only if there was a preceding if that evaluated to false
-            // If there's no preceding if (None), skip this orphaned else block
-            let should_execute = match last_if_result {
-                Some(previous_if_was_true) => !previous_if_was_true,
-                None => {
-                    // Log warning for orphaned else block
-                    logs.push(LogEntry {
-                        log_type: "warning".to_string(),
-                        message: "Skipped orphaned else block (no preceding if)".to_string(),
-                        details: Some("Else blocks must immediately follow an if block".to_string()),
-                    });
-                    false
-                }
-            };
-
-            if should_execute {
-                if let Some(children) = &node.children {
-                    process_children(
-                        children,
-                        parent_path,
-                        variables,
-                        dry_run,
-                        overwrite,
-                        logs,
-                        summary,
-                        created_items,
-                    )?;
-                }
-            }
-
-            return Ok(());
-        }
-        "repeat" => {
-            let count_str = node.repeat_count.as_deref().unwrap_or("1");
-            let as_var = node.repeat_as.as_deref().unwrap_or("i");
-
-            // Validate 'as' variable name:
-            // - Must be non-empty
-            // - Must contain only alphanumeric characters or underscores
-            // - Must not start with a digit (conventional variable naming)
-            let first_char = as_var.chars().next();
-            if as_var.is_empty()
-                || !as_var.chars().all(|c| c.is_alphanumeric() || c == '_')
-                || first_char.map_or(false, |c| c.is_ascii_digit())
-            {
-                log_repeat_error(
-                    logs,
-                    summary,
-                    format!("Invalid repeat variable name: '{}'", as_var),
-                    "Variable name must be non-empty, start with a letter or underscore, and contain only alphanumeric characters or underscores".to_string(),
-                );
-                return Ok(());
-            }
-
-            // Warn about potentially confusing variable names ending in _1
-            // Since %var_1% is the 1-indexed version, %n_1% would create %n_1% and %n_1_1%
-            if as_var.ends_with("_1") {
-                logs.push(LogEntry {
-                    log_type: "warning".to_string(),
-                    message: format!(
-                        "Variable name '{}' ends with '_1' which may be confusing",
-                        as_var
-                    ),
-                    details: Some(format!(
-                        "The 1-indexed variable will be '%{}_1%'. Consider using a different name.",
-                        as_var
-                    )),
-                });
-            }
-
-            // Resolve count (may contain variable references)
-            let resolved = substitute_variables(count_str, variables);
-
-            // Parse count to integer with safe bounds checking
-            let count: usize = match resolved.trim().parse::<i64>() {
-                Ok(n) if n < 0 => {
-                    log_repeat_error(
-                        logs,
-                        summary,
-                        format!("Repeat count cannot be negative: '{}'", resolved),
-                        format!(
-                            "Count must be a non-negative integer (resolved from '{}')",
-                            count_str
-                        ),
-                    );
-                    return Ok(());
-                }
-                // Safe conversion: check against MAX_REPEAT_COUNT before casting
-                // This prevents overflow on 32-bit systems where usize is smaller than i64
-                Ok(n) if n as u64 > MAX_REPEAT_COUNT as u64 => {
-                    log_repeat_error(
-                        logs,
-                        summary,
-                        format!(
-                            "Repeat count '{}' exceeds maximum of {}",
-                            n, MAX_REPEAT_COUNT
-                        ),
-                        "Consider reducing the count or splitting into multiple repeat blocks"
-                            .to_string(),
-                    );
-                    return Ok(());
-                }
-                Ok(n) => n as usize,
-                Err(_) => {
-                    log_repeat_error(
-                        logs,
-                        summary,
-                        format!("Invalid repeat count: '{}'", resolved),
-                        format!(
-                            "Count must be a non-negative integer (resolved from '{}')",
-                            count_str
-                        ),
-                    );
-                    return Ok(());
-                }
-            };
-
-            // Log the repeat operation
-            if count == 0 {
-                // Provide accurate details: distinguish literal "0" from variable that resolved to 0
-                let details = if count_str == "0" {
-                    "Count is explicitly set to 0".to_string()
-                } else {
-                    format!("Count '{}' resolved to 0", count_str)
-                };
-                logs.push(LogEntry {
-                    log_type: "info".to_string(),
-                    message: "Skipping repeat block (count is 0)".to_string(),
-                    details: Some(details),
-                });
-            } else if dry_run {
-                logs.push(LogEntry {
-                    log_type: "info".to_string(),
-                    message: format!("Would repeat {} times (as %{}%)", count, as_var),
-                    details: None,
-                });
-            } else {
-                logs.push(LogEntry {
-                    log_type: "info".to_string(),
-                    message: format!("Repeating {} times (as %{}%)", count, as_var),
-                    details: None,
-                });
-            }
-
-            // Process children N times
-            if let Some(children) = &node.children {
-                // Clone variables once before the loop for efficiency
-                let mut scoped_vars = variables.clone();
-                let var_0_key = format!("%{}%", as_var);
-                let var_1_key = format!("%{}_1%", as_var);
-
-                for i in 0..count {
-                    // Update iteration variables in-place (more efficient than cloning per iteration)
-                    scoped_vars.insert(var_0_key.clone(), i.to_string());
-                    scoped_vars.insert(var_1_key.clone(), (i + 1).to_string());
-
-                    process_children(
-                        children,
-                        parent_path,
-                        &scoped_vars,
-                        dry_run,
-                        overwrite,
-                        logs,
-                        summary,
-                        created_items,
-                    )?;
-                }
-            }
-
-            return Ok(());
-        }
-        _ => {}
-    }
-
-    // Replace variables in name
-    let name = substitute_variables(&node.name, variables);
-
-    let current_path = parent_path.join(&name);
+    let name = &node.name;
+    let current_path = parent_path.join(name);
     let display_path = current_path.display().to_string();
 
-    match node.node_type.as_str() {
-        "folder" => {
+    match &node.kind {
+        PlanKind::Folder { children } => {
             let pre_existed = current_path.exists();
             if dry_run {
                 logs.push(LogEntry {
@@ -546,10 +289,9 @@ fn create_node_internal(
                 });
             }
 
-            // Process children
-            if let Some(children) = &node.children {
-                process_children(
-                    children,
+            for child in children {
+                execute_plan_node(
+                    child,
                     &current_path,
                     variables,
                     dry_run,
@@ -560,7 +302,7 @@ fn create_node_internal(
                 )?;
             }
         }
-        "file" => {
+        PlanKind::File { content } => {
             let file_exists = current_path.exists();
             let pre_existed = file_exists;
 
@@ -575,29 +317,33 @@ fn create_node_internal(
             }
 
             if dry_run {
-                if let Some(url) = &node.url {
-                    logs.push(LogEntry {
-                        log_type: "info".to_string(),
-                        message: format!("Would download: {}", name),
-                        details: Some(url.clone()),
-                    });
-                } else if let Some(generator_type) = &node.generate {
-                    let generator_desc = match generator_type.as_str() {
-                        "image" => "image",
-                        "sqlite" => "database",
-                        _ => "file",
-                    };
-                    logs.push(LogEntry {
-                        log_type: "info".to_string(),
-                        message: format!("Would generate {}: {}", generator_desc, name),
-                        details: Some(display_path.clone()),
-                    });
-                } else {
-                    logs.push(LogEntry {
-                        log_type: "info".to_string(),
-                        message: format!("Would create file: {}", name),
-                        details: Some(display_path.clone()),
-                    });
+                match content {
+                    PlanContent::Download { url } => {
+                        logs.push(LogEntry {
+                            log_type: "info".to_string(),
+                            message: format!("Would download: {}", name),
+                            details: Some(url.clone()),
+                        });
+                    }
+                    PlanContent::Generate { node } => {
+                        let generator_desc = match node.generate.as_deref() {
+                            Some("image") => "image",
+                            Some("sqlite") => "database",
+                            _ => "file",
+                        };
+                        logs.push(LogEntry {
+                            log_type: "info".to_string(),
+                            message: format!("Would generate {}: {}", generator_desc, name),
+                            details: Some(display_path.clone()),
+                        });
+                    }
+                    PlanContent::Inline { .. } => {
+                        logs.push(LogEntry {
+                            log_type: "info".to_string(),
+                            message: format!("Would create file: {}", name),
+                            details: Some(display_path.clone()),
+                        });
+                    }
                 }
             } else {
                 // Ensure parent directory exists
@@ -608,347 +354,362 @@ fn create_node_internal(
                     }
                 }
 
-                if let Some(url) = &node.url {
-                    // Check if this is a binary file that needs special processing
-                    if is_office_file(&name)
-                        || is_epub_file(&name)
-                        || is_pdf_file(&name)
-                        || is_image_with_xmp(&name)
-                        || is_audio_with_metadata(&name)
-                        || is_sqlite_database(&name)
-                        || is_processable_archive(&name)
-                    {
-                        // Download as binary and process
-                        match download_file_binary(url) {
-                            Ok(data) => {
-                                let (process_result, file_type) = if is_office_file(&name) {
-                                    (process_office_file(&data, variables, &name), "Office")
-                                } else if is_epub_file(&name) {
-                                    (process_epub_file(&data, variables), "EPUB")
-                                } else if is_pdf_file(&name) {
-                                    (process_pdf_file(&data, variables), "PDF")
-                                } else if is_audio_with_metadata(&name) {
-                                    (process_audio_metadata(&data, variables, &name), "Audio")
-                                } else if is_sqlite_database(&name) {
-                                    (process_sqlite_database(&data, variables), "SQLite")
-                                } else if is_processable_archive(&name) {
-                                    (process_archive(&data, variables, &name, 0), "Archive")
-                                } else {
-                                    (process_image_xmp(&data, variables, &name), "Image")
-                                };
+                match content {
+                    PlanContent::Download { url } => {
+                        execute_download(
+                            url,
+                            name,
+                            &current_path,
+                            &display_path,
+                            variables,
+                            pre_existed,
+                            logs,
+                            summary,
+                            created_items,
+                        );
+                    }
+                    PlanContent::Generate { node: schema_node } => {
+                        execute_generate(
+                            schema_node,
+                            name,
+                            &current_path,
+                            &display_path,
+                            variables,
+                            dry_run,
+                            pre_existed,
+                            logs,
+                            summary,
+                            created_items,
+                        );
+                    }
+                    PlanContent::Inline { text, had_content } => {
+                        match fs::write(&current_path, text) {
+                            Ok(_) => {
+                                summary.files_created += 1;
+                                created_items.push(CreatedItem {
+                                    path: display_path.clone(),
+                                    item_type: ItemType::File,
+                                    pre_existed,
+                                });
+                                logs.push(LogEntry {
+                                    log_type: "success".to_string(),
+                                    message: format!("Created file: {}", name),
+                                    details: Some(if *had_content {
+                                        format!("{} ({} bytes)", display_path, text.len())
+                                    } else {
+                                        display_path.clone()
+                                    }),
+                                });
+                            }
+                            Err(e) => {
+                                summary.errors += 1;
+                                logs.push(LogEntry {
+                                    log_type: "error".to_string(),
+                                    message: format!("Failed to create file: {}", name),
+                                    details: Some(format!("Error: {}", e)),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 
-                                match process_result {
-                                    Ok(processed_data) => {
-                                        match fs::write(&current_path, &processed_data) {
-                                            Ok(_) => {
-                                                summary.files_downloaded += 1;
-                                                created_items.push(CreatedItem {
-                                                    path: display_path.clone(),
-                                                    item_type: ItemType::File,
-                                                    pre_existed,
-                                                });
-                                                logs.push(LogEntry {
-                                                    log_type: "success".to_string(),
-                                                    message: format!(
-                                                        "Downloaded & processed: {}",
-                                                        name
-                                                    ),
-                                                    details: Some(format!(
-                                                        "From: {} ({} file, variables replaced)",
-                                                        url, file_type
-                                                    )),
-                                                });
-                                            }
-                                            Err(e) => {
-                                                summary.errors += 1;
-                                                logs.push(LogEntry {
-                                                    log_type: "error".to_string(),
-                                                    message: format!(
-                                                        "Failed to save file: {}",
-                                                        name
-                                                    ),
-                                                    details: Some(format!(
-                                                        "Error writing to disk: {}",
-                                                        e
-                                                    )),
-                                                });
-                                            }
-                                        }
-                                    }
-                                    Err(e) => {
-                                        summary.errors += 1;
-                                        logs.push(LogEntry {
-                                            log_type: "error".to_string(),
-                                            message: format!(
-                                                "Failed to process {} file: {}",
-                                                file_type, name
-                                            ),
-                                            details: Some(e),
-                                        });
-                                    }
-                                }
-                            }
-                            Err(e) => {
-                                summary.errors += 1;
-                                let error_details = parse_download_error(url, &e);
-                                logs.push(LogEntry {
-                                    log_type: "error".to_string(),
-                                    message: format!("Download failed: {}", name),
-                                    details: Some(error_details),
-                                });
-                            }
-                        }
-                    } else if is_jupyter_notebook(&name) {
-                        // Download Jupyter notebook and process JSON
-                        match download_file(url) {
-                            Ok(content) => {
-                                let processed = match process_jupyter_notebook(&content, variables)
-                                {
-                                    Ok(p) => p,
-                                    Err(e) => {
-                                        // If processing fails, fall back to simple string replacement
-                                        logs.push(LogEntry {
-                                            log_type: "warning".to_string(),
-                                            message: format!(
-                                                "Notebook processing failed, using text replacement: {}",
-                                                name
-                                            ),
-                                            details: Some(e),
-                                        });
-                                        let fallback = substitute_variables(&content, variables);
-                                        fallback
-                                    }
-                                };
-                                match fs::write(&current_path, &processed) {
-                                    Ok(_) => {
-                                        summary.files_downloaded += 1;
-                                        created_items.push(CreatedItem {
-                                            path: display_path.clone(),
-                                            item_type: ItemType::File,
-                                            pre_existed,
-                                        });
-                                        logs.push(LogEntry {
-                                            log_type: "success".to_string(),
-                                            message: format!("Downloaded & processed: {}", name),
-                                            details: Some(format!(
-                                                "From: {} (Jupyter notebook, variables replaced)",
-                                                url
-                                            )),
-                                        });
-                                    }
-                                    Err(e) => {
-                                        summary.errors += 1;
-                                        logs.push(LogEntry {
-                                            log_type: "error".to_string(),
-                                            message: format!("Failed to save file: {}", name),
-                                            details: Some(format!("Error writing to disk: {}", e)),
-                                        });
-                                    }
-                                }
-                            }
-                            Err(e) => {
-                                summary.errors += 1;
-                                let error_details = parse_download_error(url, &e);
-                                logs.push(LogEntry {
-                                    log_type: "error".to_string(),
-                                    message: format!("Download failed: {}", name),
-                                    details: Some(error_details),
-                                });
-                            }
-                        }
-                    } else {
-                        // Download regular text file (includes SVG which is XML text)
-                        match download_file(url) {
-                            Ok(content) => {
-                                // Replace variables in downloaded content
-                                let file_content = substitute_variables(&content, variables);
-                                match fs::write(&current_path, &file_content) {
-                                    Ok(_) => {
-                                        summary.files_downloaded += 1;
-                                        created_items.push(CreatedItem {
-                                            path: display_path.clone(),
-                                            item_type: ItemType::File,
-                                            pre_existed,
-                                        });
-                                        let details = if is_svg_file(&name) {
-                                            format!("From: {} (SVG, variables replaced)", url)
-                                        } else {
-                                            format!("From: {}", url)
-                                        };
-                                        logs.push(LogEntry {
-                                            log_type: "success".to_string(),
-                                            message: format!("Downloaded: {}", name),
-                                            details: Some(details),
-                                        });
-                                    }
-                                    Err(e) => {
-                                        summary.errors += 1;
-                                        logs.push(LogEntry {
-                                            log_type: "error".to_string(),
-                                            message: format!("Failed to save file: {}", name),
-                                            details: Some(format!("Error writing to disk: {}", e)),
-                                        });
-                                    }
-                                }
-                            }
-                            Err(e) => {
-                                summary.errors += 1;
-                                // Parse error for better user feedback
-                                let error_details = parse_download_error(url, &e);
-                                logs.push(LogEntry {
-                                    log_type: "error".to_string(),
-                                    message: format!("Download failed: {}", name),
-                                    details: Some(error_details),
-                                });
-                                // Don't create file on download error
-                            }
-                        }
-                    }
-                } else if let Some(generator_type) = &node.generate {
-                    // Generate binary file (image or sqlite)
-                    match generator_type.as_str() {
-                        "image" => {
-                            match generators::generate_image(node, &current_path, variables, dry_run)
-                            {
-                                Ok(_) => {
-                                    summary.files_generated += 1;
-                                    if !dry_run {
-                                        created_items.push(CreatedItem {
-                                            path: display_path.clone(),
-                                            item_type: ItemType::File,
-                                            pre_existed,
-                                        });
-                                    }
-                                    logs.push(LogEntry {
-                                        log_type: if dry_run {
-                                            "info".to_string()
-                                        } else {
-                                            "success".to_string()
-                                        },
-                                        message: format!(
-                                            "{} image: {}",
-                                            if dry_run { "Would generate" } else { "Generated" },
-                                            name
-                                        ),
-                                        details: Some(display_path.clone()),
-                                    });
-                                }
-                                Err(e) => {
-                                    summary.errors += 1;
-                                    logs.push(LogEntry {
-                                        log_type: "error".to_string(),
-                                        message: format!("Failed to generate image: {}", name),
-                                        details: Some(e),
-                                    });
-                                }
-                            }
-                        }
-                        "sqlite" => {
-                            match generators::generate_sqlite(
-                                node,
-                                &current_path,
-                                variables,
-                                dry_run,
-                            ) {
-                                Ok(_) => {
-                                    summary.files_generated += 1;
-                                    if !dry_run {
-                                        created_items.push(CreatedItem {
-                                            path: display_path.clone(),
-                                            item_type: ItemType::File,
-                                            pre_existed,
-                                        });
-                                    }
-                                    logs.push(LogEntry {
-                                        log_type: if dry_run {
-                                            "info".to_string()
-                                        } else {
-                                            "success".to_string()
-                                        },
-                                        message: format!(
-                                            "{} database: {}",
-                                            if dry_run { "Would generate" } else { "Generated" },
-                                            name
-                                        ),
-                                        details: Some(display_path.clone()),
-                                    });
-                                }
-                                Err(e) => {
-                                    summary.errors += 1;
-                                    logs.push(LogEntry {
-                                        log_type: "error".to_string(),
-                                        message: format!("Failed to generate database: {}", name),
-                                        details: Some(e),
-                                    });
-                                }
-                            }
-                        }
-                        _ => {
-                            logs.push(LogEntry {
-                                log_type: "warning".to_string(),
-                                message: format!("Unknown generator type: {}", generator_type),
-                                details: Some(format!(
-                                    "File '{}' was skipped. Supported generators: image, sqlite",
-                                    name
-                                )),
-                            });
-                        }
-                    }
+    Ok(())
+}
+
+/// Download a planned file, applying variable substitution / binary
+/// processing to the fetched content based on the resolved file name.
+fn execute_download(
+    url: &str,
+    name: &str,
+    current_path: &PathBuf,
+    display_path: &str,
+    variables: &HashMap<String, String>,
+    pre_existed: bool,
+    logs: &mut Vec<LogEntry>,
+    summary: &mut ResultSummary,
+    created_items: &mut Vec<CreatedItem>,
+) {
+    // Check if this is a binary file that needs special processing
+    if is_office_file(name)
+        || is_epub_file(name)
+        || is_pdf_file(name)
+        || is_image_with_xmp(name)
+        || is_audio_with_metadata(name)
+        || is_sqlite_database(name)
+        || is_processable_archive(name)
+    {
+        // Download as binary and process
+        match download_file_binary(url) {
+            Ok(data) => {
+                let (process_result, file_type) = if is_office_file(name) {
+                    (process_office_file(&data, variables, name), "Office")
+                } else if is_epub_file(name) {
+                    (process_epub_file(&data, variables), "EPUB")
+                } else if is_pdf_file(name) {
+                    (process_pdf_file(&data, variables), "PDF")
+                } else if is_audio_with_metadata(name) {
+                    (process_audio_metadata(&data, variables, name), "Audio")
+                } else if is_sqlite_database(name) {
+                    (process_sqlite_database(&data, variables), "SQLite")
+                } else if is_processable_archive(name) {
+                    (process_archive(&data, variables, name, 0), "Archive")
                 } else {
-                    // Create file with content (or empty if no content)
-                    // Process template directives if template="true", then replace variables
-                    let raw_content = node.content.clone().unwrap_or_default();
-                    let file_content = if node.template == Some(true) {
-                        match templating::process_template(&raw_content, variables) {
-                            Ok(processed) => substitute_variables(&processed, variables),
-                            Err(e) => {
-                                logs.push(LogEntry {
-                                    log_type: "warning".to_string(),
-                                    message: format!("Template error in {}", name),
-                                    details: Some(e.to_string()),
-                                });
-                                substitute_variables(&raw_content, variables)
-                            }
-                        }
-                    } else {
-                        substitute_variables(&raw_content, variables)
-                    };
-                    match fs::write(&current_path, &file_content) {
+                    (process_image_xmp(&data, variables, name), "Image")
+                };
+
+                match process_result {
+                    Ok(processed_data) => match fs::write(current_path, &processed_data) {
                         Ok(_) => {
-                            summary.files_created += 1;
+                            summary.files_downloaded += 1;
                             created_items.push(CreatedItem {
-                                path: display_path.clone(),
+                                path: display_path.to_string(),
                                 item_type: ItemType::File,
                                 pre_existed,
                             });
-                            let has_content = node.content.is_some();
                             logs.push(LogEntry {
                                 log_type: "success".to_string(),
-                                message: format!("Created file: {}", name),
-                                details: Some(if has_content {
-                                    format!("{} ({} bytes)", display_path, file_content.len())
-                                } else {
-                                    display_path.clone()
-                                }),
+                                message: format!("Downloaded & processed: {}", name),
+                                details: Some(format!(
+                                    "From: {} ({} file, variables replaced)",
+                                    url, file_type
+                                )),
                             });
                         }
                         Err(e) => {
                             summary.errors += 1;
                             logs.push(LogEntry {
                                 log_type: "error".to_string(),
-                                message: format!("Failed to create file: {}", name),
-                                details: Some(format!("Error: {}", e)),
+                                message: format!("Failed to save file: {}", name),
+                                details: Some(format!("Error writing to disk: {}", e)),
                             });
                         }
+                    },
+                    Err(e) => {
+                        summary.errors += 1;
+                        logs.push(LogEntry {
+                            log_type: "error".to_string(),
+                            message: format!("Failed to process {} file: {}", file_type, name),
+                            details: Some(e),
+                        });
                     }
                 }
             }
+            Err(e) => {
+                summary.errors += 1;
+                let error_details = parse_download_error(url, &e);
+                logs.push(LogEntry {
+                    log_type: "error".to_string(),
+                    message: format!("Download failed: {}", name),
+                    details: Some(error_details),
+                });
+            }
         }
-        _ => {}
+    } else if is_jupyter_notebook(name) {
+        // Download Jupyter notebook and process JSON
+        match download_file(url) {
+            Ok(content) => {
+                let processed = match process_jupyter_notebook(&content, variables) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        // If processing fails, fall back to simple string replacement
+                        logs.push(LogEntry {
+                            log_type: "warning".to_string(),
+                            message: format!(
+                                "Notebook processing failed, using text replacement: {}",
+                                name
+                            ),
+                            details: Some(e),
+                        });
+                        substitute_variables(&content, variables)
+                    }
+                };
+                match fs::write(current_path, &processed) {
+                    Ok(_) => {
+                        summary.files_downloaded += 1;
+                        created_items.push(CreatedItem {
+                            path: display_path.to_string(),
+                            item_type: ItemType::File,
+                            pre_existed,
+                        });
+                        logs.push(LogEntry {
+                            log_type: "success".to_string(),
+                            message: format!("Downloaded & processed: {}", name),
+                            details: Some(format!(
+                                "From: {} (Jupyter notebook, variables replaced)",
+                                url
+                            )),
+                        });
+                    }
+                    Err(e) => {
+                        summary.errors += 1;
+                        logs.push(LogEntry {
+                            log_type: "error".to_string(),
+                            message: format!("Failed to save file: {}", name),
+                            details: Some(format!("Error writing to disk: {}", e)),
+                        });
+                    }
+                }
+            }
+            Err(e) => {
+                summary.errors += 1;
+                let error_details = parse_download_error(url, &e);
+                logs.push(LogEntry {
+                    log_type: "error".to_string(),
+                    message: format!("Download failed: {}", name),
+                    details: Some(error_details),
+                });
+            }
+        }
+    } else {
+        // Download regular text file (includes SVG which is XML text)
+        match download_file(url) {
+            Ok(content) => {
+                // Replace variables in downloaded content
+                let file_content = substitute_variables(&content, variables);
+                match fs::write(current_path, &file_content) {
+                    Ok(_) => {
+                        summary.files_downloaded += 1;
+                        created_items.push(CreatedItem {
+                            path: display_path.to_string(),
+                            item_type: ItemType::File,
+                            pre_existed,
+                        });
+                        let details = if is_svg_file(name) {
+                            format!("From: {} (SVG, variables replaced)", url)
+                        } else {
+                            format!("From: {}", url)
+                        };
+                        logs.push(LogEntry {
+                            log_type: "success".to_string(),
+                            message: format!("Downloaded: {}", name),
+                            details: Some(details),
+                        });
+                    }
+                    Err(e) => {
+                        summary.errors += 1;
+                        logs.push(LogEntry {
+                            log_type: "error".to_string(),
+                            message: format!("Failed to save file: {}", name),
+                            details: Some(format!("Error writing to disk: {}", e)),
+                        });
+                    }
+                }
+            }
+            Err(e) => {
+                summary.errors += 1;
+                // Parse error for better user feedback
+                let error_details = parse_download_error(url, &e);
+                logs.push(LogEntry {
+                    log_type: "error".to_string(),
+                    message: format!("Download failed: {}", name),
+                    details: Some(error_details),
+                });
+                // Don't create file on download error
+            }
+        }
     }
-
-    Ok(())
 }
+
+/// Run a generator (image or sqlite) for a planned file.
+fn execute_generate(
+    schema_node: &crate::schema::SchemaNode,
+    name: &str,
+    current_path: &PathBuf,
+    display_path: &str,
+    variables: &HashMap<String, String>,
+    dry_run: bool,
+    pre_existed: bool,
+    logs: &mut Vec<LogEntry>,
+    summary: &mut ResultSummary,
+    created_items: &mut Vec<CreatedItem>,
+) {
+    match schema_node.generate.as_deref() {
+        Some("image") => {
+            match generators::generate_image(schema_node, current_path, variables, dry_run) {
+                Ok(_) => {
+                    summary.files_generated += 1;
+                    if !dry_run {
+                        created_items.push(CreatedItem {
+                            path: display_path.to_string(),
+                            item_type: ItemType::File,
+                            pre_existed,
+                        });
+                    }
+                    logs.push(LogEntry {
+                        log_type: if dry_run {
+                            "info".to_string()
+                        } else {
+                            "success".to_string()
+                        },
+                        message: format!(
+                            "{} image: {}",
+                            if dry_run { "Would generate" } else { "Generated" },
+                            name
+                        ),
+                        details: Some(display_path.to_string()),
+                    });
+                }
+                Err(e) => {
+                    summary.errors += 1;
+                    logs.push(LogEntry {
+                        log_type: "error".to_string(),
+                        message: format!("Failed to generate image: {}", name),
+                        details: Some(e),
+                    });
+                }
+            }
+        }
+        Some("sqlite") => {
+            match generators::generate_sqlite(schema_node, current_path, variables, dry_run) {
+                Ok(_) => {
+                    summary.files_generated += 1;
+                    if !dry_run {
+                        created_items.push(CreatedItem {
+                            path: display_path.to_string(),
+                            item_type: ItemType::File,
+                            pre_existed,
+                        });
+                    }
+                    logs.push(LogEntry {
+                        log_type: if dry_run {
+                            "info".to_string()
+                        } else {
+                            "success".to_string()
+                        },
+                        message: format!(
+                            "{} database: {}",
+                            if dry_run { "Would generate" } else { "Generated" },
+                            name
+                        ),
+                        details: Some(display_path.to_string()),
+                    });
+                }
+                Err(e) => {
+                    summary.errors += 1;
+                    logs.push(LogEntry {
+                        log_type: "error".to_string(),
+                        message: format!("Failed to generate database: {}", name),
+                        details: Some(e),
+                    });
+                }
+            }
+        }
+        other => {
+            logs.push(LogEntry {
+                log_type: "warning".to_string(),
+                message: format!("Unknown generator type: {}", other.unwrap_or("")),
+                details: Some(format!(
+                    "File '{}' was skipped. Supported generators: image, sqlite",
+                    name
+                )),
+            });
+        }
+    }
+}
+
 
 /// Undo a structure creation by deleting items that were newly created
 /// Safety rules:
@@ -1589,10 +1350,10 @@ mod tests {
         }
     }
 
-    // Golden-vector contract (ADR-0002): pins schema-structure semantics
-    // (variable substitution in names, repeat expansion, condition eval)
-    // across targets. Runs the planning engine (`generate_diff_preview`) and
-    // collects the planned relative paths from the resulting DiffNode tree.
+    // Golden-vector contract (ADR-0002, ADR-0004): pins schema-structure
+    // semantics (variable substitution in names, repeat expansion, condition
+    // eval, loud-error edges) across targets. Runs the production Plan
+    // expansion — the same code structure creation executes.
     #[test]
     fn test_schema_structure_matches_golden_contract() {
         use std::collections::HashMap;
@@ -1608,45 +1369,15 @@ mod tests {
             expected_errors: usize,
         }
 
-        fn collect_paths(node: &crate::types::DiffNode, prefix: &str, out: &mut Vec<String>) {
-            let p = node
-                .path
-                .strip_prefix(prefix)
-                .unwrap_or(node.path.as_str())
-                .trim_start_matches('/');
-            if !p.is_empty() {
-                out.push(p.to_string());
-            }
-            if let Some(children) = &node.children {
-                for child in children {
-                    collect_paths(child, prefix, out);
-                }
-            }
-        }
-
         let fixture = include_str!("../../../../fixtures/schema-structure.json");
         let cases: Vec<Case> = serde_json::from_str(fixture).expect("valid fixture JSON");
         assert!(!cases.is_empty(), "schema-structure fixture must contain cases");
 
         for case in &cases {
-            // Output path does not need to exist; with no existing files the
-            // planner treats every item as a Create. Use a stable fake path so
-            // diff_preview's relative-to-output logic produces clean paths.
-            let result = crate::diff_preview::generate_diff_preview(
-                &case.tree,
-                "/sc-contract-101",
-                &case.variables,
-                false, // overwrite
-            )
-            .unwrap_or_else(|e| panic!("case '{}' failed: {}", case.name, e));
+            let structure_plan = crate::plan::expand(&case.tree, &case.variables);
 
-            let mut paths: Vec<String> = Vec::new();
-            collect_paths(&result.root, "/sc-contract-101", &mut paths);
-            // The DiffNode tree wraps repeat/if blocks in virtual nodes that
-            // re-emit the parent path. Dedup so the contract sees the same
-            // unique path set both targets actually plan to create.
+            let mut paths = crate::plan::to_paths(&structure_plan);
             paths.sort();
-            paths.dedup();
 
             let mut expected = case.expected_paths.clone();
             expected.sort();
@@ -1658,11 +1389,11 @@ mod tests {
             );
 
             assert_eq!(
-                result.summary.warnings.len(),
+                structure_plan.error_count(),
                 case.expected_errors,
-                "case '{}': loud-error count mismatch (warnings: {:?})",
+                "case '{}': loud-error count mismatch (notes: {:?})",
                 case.name,
-                result.summary.warnings
+                structure_plan.notes
             );
         }
     }


### PR DESCRIPTION
Closes #123. Second slice of the Plan-module migration (ADR-0004).

## What

- New `plan.rs`: `expand(tree, variables) → Plan`, pure (no fs/network/clock; caller injects built-ins). Plan = tree of resolved nodes — `Inline` content fully rendered (templating → substitution), `Download`/`Generate` deferred as instructions, `If`/`Else`/`Repeat` provenance recorded per node. Loud errors and repeat announcements travel as Plan notes. `to_paths` flattener for the contract. 9 unit tests including determinism.
- `structure_creator.rs`: create walker (`create_node_internal` family, `is_truthy`, `evaluate_if_condition`, `process_children`) deleted; `create_structure_from_tree` expands then executes. Executor preserves existing log strings, summary counts, dry-run phrasing ("Would repeat …" asserted by CLI tests), skip/overwrite behaviour, download/generator pipelines, hooks.
- Schema-structure contract test repointed from `generate_diff_preview` to production `plan::expand`, now also asserting loud-error counts. Path dedup hack gone — the Plan has no virtual duplicate nodes.
- `SchemaNode` gains `PartialEq` (needed for Plan equality; harmless serde-wise).
- `MAX_REPEAT_COUNT` moved to `plan.rs`, re-exported from `structure_creator` so `diff_preview` and CLI tests are untouched. `diff_preview.rs` still has its own walker — replaced in #124.

## Behaviour notes

- Expansion-time logs (repeat announcements/errors) now emit before creation logs instead of interleaved. Content unchanged; CLI assertions are `contains`-based and pass.
- Found while porting: Rust truthiness also treats `no`/`off`/`disabled` as falsy, web only `false`/`0` — live unpinned divergence, filed as a follow-up issue rather than destabilizing in-flight #125.

## Tests

Rust: 261 lib (9 new) + 49 + 46 integration, all green. TS untouched.