### PR TITLE
One truthiness rule across Targets and engines

### DIFF
--- a/apps/desktop/src-tauri/src/plan.rs
+++ b/apps/desktop/src-tauri/src/plan.rs
@@ -127,24 +127,12 @@ fn collect_paths(node: &PlanNode, prefix: &str, out: &mut Vec<String>) {
     }
 }
 
-/// Check if a string value is "truthy".
-/// Empty strings and common falsy values ("false", "0", "no") are considered false
-fn is_truthy(value: &str) -> bool {
-    if value.is_empty() {
-        return false;
-    }
-    !matches!(
-        value.to_lowercase().as_str(),
-        "false" | "0" | "no" | "off" | "disabled"
-    )
-}
-
 fn evaluate_if_condition(node: &SchemaNode, variables: &HashMap<String, String>) -> bool {
     if let Some(var_name) = &node.condition_var {
         let lookup_key = format!("%{}%", var_name);
         variables
             .get(&lookup_key)
-            .map(|v| is_truthy(v))
+            .map(|v| crate::transforms::is_truthy_value(v))
             .unwrap_or(false)
     } else {
         false

--- a/apps/desktop/src-tauri/src/templating.rs
+++ b/apps/desktop/src-tauri/src/templating.rs
@@ -89,10 +89,7 @@ static TEMPLATE_VAR_REGEX: Lazy<Regex> = Lazy::new(|| {
 fn is_truthy(variables: &HashMap<String, String>, var_name: &str) -> bool {
     let key = format!("%{}%", var_name);
     match variables.get(&key) {
-        Some(value) => {
-            let trimmed = value.trim().to_lowercase();
-            !trimmed.is_empty() && trimmed != "false" && trimmed != "0"
-        }
+        Some(value) => crate::transforms::is_truthy_value(value),
         None => false,
     }
 }

--- a/apps/desktop/src-tauri/src/transforms.rs
+++ b/apps/desktop/src-tauri/src/transforms.rs
@@ -201,6 +201,17 @@ pub fn extract_variables_from_content(content: &str) -> Vec<String> {
 ///
 /// Unknown transformations are silently left as-is (the variable reference remains unchanged).
 /// This allows forward compatibility with new transforms while making typos visible in output.
+/// Shared truthiness rule for `<if>` schema conditions and `{{if}}` template
+/// directives (ADR-0004, issue #129): the value is trimmed and lowercased;
+/// blank values and "false", "0", "no", "off", "disabled" are falsy,
+/// everything else is truthy.
+pub fn is_truthy_value(value: &str) -> bool {
+    !matches!(
+        value.trim().to_lowercase().as_str(),
+        "" | "false" | "0" | "no" | "off" | "disabled"
+    )
+}
+
 pub fn substitute_variables(text: &str, variables: &HashMap<String, String>) -> String {
     let refs = find_variable_refs(text);
     let mut result = text.to_string();

--- a/fixtures/schema-structure.json
+++ b/fixtures/schema-structure.json
@@ -127,6 +127,75 @@
     "expectedPaths": ["root", "root/x-0.txt", "root/x-1.txt"]
   },
   {
+    "name": "if with no off disabled values is falsy",
+    "tree": {
+      "root": {
+        "type": "folder",
+        "name": "root",
+        "children": [
+          {
+            "type": "if",
+            "name": "",
+            "condition_var": "A",
+            "children": [{ "type": "file", "name": "a.txt" }]
+          },
+          {
+            "type": "if",
+            "name": "",
+            "condition_var": "B",
+            "children": [{ "type": "file", "name": "b.txt" }]
+          },
+          {
+            "type": "if",
+            "name": "",
+            "condition_var": "C",
+            "children": [{ "type": "file", "name": "c.txt" }]
+          },
+          {
+            "type": "if",
+            "name": "",
+            "condition_var": "D",
+            "children": [{ "type": "file", "name": "d.txt" }]
+          }
+        ]
+      },
+      "stats": { "folders": 0, "files": 0, "downloads": 0, "generated": 0 }
+    },
+    "variables": {
+      "%A%": "no",
+      "%B%": "OFF",
+      "%C%": "Disabled",
+      "%D%": "yes"
+    },
+    "expectedPaths": ["root", "root/d.txt"]
+  },
+  {
+    "name": "if truthiness trims whitespace before evaluating",
+    "tree": {
+      "root": {
+        "type": "folder",
+        "name": "root",
+        "children": [
+          {
+            "type": "if",
+            "name": "",
+            "condition_var": "PADDED",
+            "children": [{ "type": "file", "name": "padded.txt" }]
+          },
+          {
+            "type": "if",
+            "name": "",
+            "condition_var": "BLANK",
+            "children": [{ "type": "file", "name": "blank.txt" }]
+          }
+        ]
+      },
+      "stats": { "folders": 0, "files": 0, "downloads": 0, "generated": 0 }
+    },
+    "variables": { "%PADDED%": " false ", "%BLANK%": "   " },
+    "expectedPaths": ["root"]
+  },
+  {
     "name": "repeat with missing count defaults to one iteration",
     "tree": {
       "root": {

--- a/fixtures/templating.json
+++ b/fixtures/templating.json
@@ -20,6 +20,26 @@
     "expected": "no"
   },
   {
+    "template": "{{if FLAG}}yes{{else}}no{{endif}}",
+    "variables": { "%FLAG%": "No" },
+    "expected": "no"
+  },
+  {
+    "template": "{{if FLAG}}yes{{else}}no{{endif}}",
+    "variables": { "%FLAG%": "off" },
+    "expected": "no"
+  },
+  {
+    "template": "{{if FLAG}}yes{{else}}no{{endif}}",
+    "variables": { "%FLAG%": "DISABLED" },
+    "expected": "no"
+  },
+  {
+    "template": "{{if FLAG}}yes{{else}}no{{endif}}",
+    "variables": { "%FLAG%": " false " },
+    "expected": "no"
+  },
+  {
     "template": "{{for x in LIST}}{{x}}-{{endfor}}",
     "variables": { "%LIST%": "a,b,c" },
     "expected": "a-b-c-"

--- a/packages/shared/src/plan.ts
+++ b/packages/shared/src/plan.ts
@@ -24,7 +24,7 @@
  */
 
 import type { SchemaNode, SchemaTree } from "./types";
-import { substituteVariables } from "./transforms";
+import { substituteVariables, isTruthyValue } from "./transforms";
 import { processTemplate } from "./templating";
 
 /** Maximum number of iterations allowed in a repeat block. */
@@ -382,6 +382,5 @@ const isTruthy = (
   if (!conditionVar) return false;
   const value = variables[`%${conditionVar}%`];
   if (value === undefined) return false;
-  const trimmed = value.trim().toLowerCase();
-  return trimmed !== "" && trimmed !== "false" && trimmed !== "0";
+  return isTruthyValue(value);
 };

--- a/packages/shared/src/templating.ts
+++ b/packages/shared/src/templating.ts
@@ -52,14 +52,15 @@ const TEMPLATE_VAR_REGEX = /\{\{(?:if|for\s+[a-z_][a-z0-9_]*\s+in)\s+([A-Za-z_][
  * Check if a variable is truthy.
  * A variable is truthy if it exists, is non-empty, is not "false", and is not "0".
  */
+import { isTruthyValue } from "./transforms";
+
 function isTruthy(variables: Record<string, string>, varName: string): boolean {
   const key = `%${varName}%`;
   const value = variables[key];
   if (value === undefined) {
     return false;
   }
-  const trimmed = value.trim().toLowerCase();
-  return trimmed !== "" && trimmed !== "false" && trimmed !== "0";
+  return isTruthyValue(value);
 }
 
 /**

--- a/packages/shared/src/transforms.ts
+++ b/packages/shared/src/transforms.ts
@@ -303,6 +303,24 @@ export const extractVariablesFromContent = (content: string): string[] => {
 };
 
 /**
+ * Shared truthiness rule for `<if>` schema conditions and `{{if}}` template
+ * directives (ADR-0004, issue #129): the value is trimmed and lowercased;
+ * blank values and "false", "0", "no", "off", "disabled" are falsy,
+ * everything else is truthy.
+ */
+export const isTruthyValue = (value: string): boolean => {
+  const trimmed = value.trim().toLowerCase();
+  return (
+    trimmed !== "" &&
+    trimmed !== "false" &&
+    trimmed !== "0" &&
+    trimmed !== "no" &&
+    trimmed !== "off" &&
+    trimmed !== "disabled"
+  );
+};
+
+/**
  * Substitute variables in a string.
  */
 export const substituteVariables = (


### PR DESCRIPTION
Closes #129.

## What

- New shared helper on each Target — Rust `transforms::is_truthy_value`, TS `isTruthyValue` in `packages/shared/src/transforms.ts`: trim, lowercase; blank, `false`, `0`, `no`, `off`, `disabled` are falsy; everything else truthy.
- All four previously-divergent sites delegate to it: native schema `<if>` (Plan expansion), native `{{if}}` templating, shared `{{if}}` templating, shared Plan `<if>`.
- Golden vectors pin the rule in both fixture sets: `no`/`OFF`/`Disabled` falsy (case-insensitive), `" false "` and whitespace-only falsy (trimmed) — schema-structure and templating cases.

## Decision note

#129 left the trim question open, defaulting to native `<if>`'s no-trim with an escape hatch if trimming proved load-bearing. It did: whitespace-only-is-falsy was asserted by existing tests on three of the four sites, and `" false "` being truthy reads as accident, not intent. So the trimmed rule won; the one behaviour change to the native Target is that padded/blank `<if>` values now evaluate falsy (and `no`/`off`/`disabled` are consistently falsy everywhere).

## Tests

Rust 261 + 49 + 46, shared 65, desktop 387 (grew — new fixture cases run through both contract suites), tsc clean.