### PR TITLE
Substitute Variables in file URLs on the native Target

### DIFF
--- a/apps/desktop/src-tauri/src/diff_preview.rs
+++ b/apps/desktop/src-tauri/src/diff_preview.rs
@@ -424,6 +424,38 @@ mod tests {
     }
 
     #[test]
+    fn preview_shows_substituted_url() {
+        let t = tree(SchemaNode {
+            name: "root".to_string(),
+            node_type: "folder".to_string(),
+            children: Some(vec![SchemaNode {
+                name: "logo.png".to_string(),
+                node_type: "file".to_string(),
+                url: Some("https://cdn.example.com/%VERSION%/logo.png".to_string()),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        });
+
+        let mut variables = HashMap::new();
+        variables.insert("%VERSION%".to_string(), "1.2.3".to_string());
+
+        let temp = tempfile::tempdir().unwrap();
+        let result =
+            generate_diff_preview(&t, temp.path().to_str().unwrap(), &variables, false).unwrap();
+
+        let file = &result.root.children.as_ref().unwrap()[0];
+        assert_eq!(
+            file.url.as_deref(),
+            Some("https://cdn.example.com/1.2.3/logo.png")
+        );
+        assert_eq!(
+            file.new_content.as_deref(),
+            Some("[Content from URL: https://cdn.example.com/1.2.3/logo.png]")
+        );
+    }
+
+    #[test]
     fn preview_and_creation_agree_on_planned_paths() {
         // The same expansion feeds both; sanity-check the diff tree mirrors
         // plan::to_paths for a schema with if/else and repeat.

--- a/apps/desktop/src-tauri/src/plan.rs
+++ b/apps/desktop/src-tauri/src/plan.rs
@@ -327,7 +327,9 @@ fn expand_node(
         }
         "file" => {
             let content = if let Some(url) = &node.url {
-                PlanContent::Download { url: url.clone() }
+                PlanContent::Download {
+                    url: substitute_variables(url, variables),
+                }
             } else if node.generate.is_some() {
                 PlanContent::Generate { node: node.clone() }
             } else {
@@ -448,20 +450,22 @@ mod tests {
     }
 
     #[test]
-    fn url_becomes_download_instruction() {
+    fn url_becomes_download_instruction_with_variables_resolved() {
         let mut f = file("logo.png");
-        f.url = Some("https://example.com/logo.png".to_string());
+        f.url = Some("https://example.com/%VERSION%/a%20b/%NOPE%/logo.png".to_string());
         let t = tree(folder("root", vec![f]));
-        let plan = expand(&t, &HashMap::new());
+        let plan = expand(&t, &vars(&[("%VERSION%", "1.2.3")]));
 
         let PlanKind::Folder { children } = &plan.roots[0].kind else {
             panic!()
         };
+        // Defined tokens resolve; percent-encoding and undefined tokens
+        // stay untouched (issue #133).
         assert!(matches!(
             &children[0].kind,
             PlanKind::File {
                 content: PlanContent::Download { url }
-            } if url == "https://example.com/logo.png"
+            } if url == "https://example.com/1.2.3/a%20b/%NOPE%/logo.png"
         ));
     }
 

--- a/apps/desktop/src-tauri/src/structure_creator.rs
+++ b/apps/desktop/src-tauri/src/structure_creator.rs
@@ -1367,6 +1367,32 @@ mod tests {
             expected_paths: Vec<String>,
             #[serde(rename = "expectedErrors", default)]
             expected_errors: usize,
+            #[serde(rename = "expectedUrls", default)]
+            expected_urls: HashMap<String, String>,
+        }
+
+        fn collect_urls(
+            node: &crate::plan::PlanNode,
+            prefix: &str,
+            out: &mut HashMap<String, String>,
+        ) {
+            let path = if prefix.is_empty() {
+                node.name.clone()
+            } else {
+                format!("{}/{}", prefix, node.name)
+            };
+            match &node.kind {
+                crate::plan::PlanKind::Folder { children } => {
+                    for child in children {
+                        collect_urls(child, &path, out);
+                    }
+                }
+                crate::plan::PlanKind::File { content } => {
+                    if let crate::plan::PlanContent::Download { url } = content {
+                        out.insert(path, url.clone());
+                    }
+                }
+            }
         }
 
         let fixture = include_str!("../../../../fixtures/schema-structure.json");
@@ -1395,6 +1421,22 @@ mod tests {
                 case.name,
                 structure_plan.notes
             );
+
+            if !case.expected_urls.is_empty() {
+                let mut urls = HashMap::new();
+                for root in &structure_plan.roots {
+                    collect_urls(root, "", &mut urls);
+                }
+                for (path, expected_url) in &case.expected_urls {
+                    assert_eq!(
+                        urls.get(path),
+                        Some(expected_url),
+                        "case '{}': URL mismatch at '{}'",
+                        case.name,
+                        path
+                    );
+                }
+            }
         }
     }
 }

--- a/apps/desktop/src/contract/schema-structure.contract.test.ts
+++ b/apps/desktop/src/contract/schema-structure.contract.test.ts
@@ -1,15 +1,15 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, it, expect } from "vitest";
-import type { SchemaTree } from "@structure-creator/shared";
+import type { SchemaTree, Plan, PlanNode } from "@structure-creator/shared";
 import { expand, toPaths } from "@structure-creator/shared";
 
 /**
  * Golden-vector contract (ADR-0002, ADR-0004). The schema-structure fixtures
- * pin structural semantics (variable substitution in names, repeat expansion,
- * condition evaluation, loud-error edges) across targets, consumed by both
- * this web TS suite (via the shared production `expand` Plan module) and the
- * Rust suite.
+ * pin structural semantics (variable substitution in names and URLs, repeat
+ * expansion, condition evaluation, loud-error edges) across targets, consumed
+ * by both this web TS suite (via the shared production `expand` Plan module)
+ * and the Rust suite.
  */
 interface SchemaStructureCase {
   name: string;
@@ -17,6 +17,7 @@ interface SchemaStructureCase {
   variables: Record<string, string>;
   expectedPaths: string[];
   expectedErrors?: number;
+  expectedUrls?: Record<string, string>;
 }
 
 const fixturePath = resolve(
@@ -27,6 +28,20 @@ const cases: SchemaStructureCase[] = JSON.parse(
   readFileSync(fixturePath, "utf-8")
 );
 
+const collectUrls = (plan: Plan): Record<string, string> => {
+  const urls: Record<string, string> = {};
+  const walk = (node: PlanNode, prefix: string): void => {
+    const path = prefix ? `${prefix}/${node.name}` : node.name;
+    if (node.kind === "folder") {
+      for (const child of node.children) walk(child, path);
+    } else if (node.content.kind === "download") {
+      urls[path] = node.content.url;
+    }
+  };
+  for (const node of plan.nodes) walk(node, "");
+  return urls;
+};
+
 describe("schema-structure golden-vector contract", () => {
   it("loads cases from the shared fixture", () => {
     expect(cases.length).toBeGreaterThan(0);
@@ -34,12 +49,18 @@ describe("schema-structure golden-vector contract", () => {
 
   it.each(cases)(
     "$name",
-    ({ tree, variables, expectedPaths, expectedErrors }) => {
+    ({ tree, variables, expectedPaths, expectedErrors, expectedUrls }) => {
       const plan = expand(tree, variables);
       const got = toPaths(plan);
       const expected = [...expectedPaths].sort();
       expect(got).toEqual(expected);
       expect(plan.errors.length).toBe(expectedErrors ?? 0);
+      if (expectedUrls) {
+        const urls = collectUrls(plan);
+        for (const [path, url] of Object.entries(expectedUrls)) {
+          expect(urls[path], `URL at ${path}`).toBe(url);
+        }
+      }
     }
   );
 });

--- a/fixtures/schema-structure.json
+++ b/fixtures/schema-structure.json
@@ -127,6 +127,45 @@
     "expectedPaths": ["root", "root/x-0.txt", "root/x-1.txt"]
   },
   {
+    "name": "url variable substitution resolves defined tokens and leaves undefined and percent-encoding untouched",
+    "tree": {
+      "root": {
+        "type": "folder",
+        "name": "root",
+        "children": [
+          {
+            "type": "file",
+            "name": "logo.png",
+            "url": "https://cdn.example.com/%VERSION%/logo.png"
+          },
+          {
+            "type": "file",
+            "name": "raw.png",
+            "url": "https://cdn.example.com/%UNDEFINED_TOKEN%/raw.png"
+          },
+          {
+            "type": "file",
+            "name": "encoded.png",
+            "url": "https://cdn.example.com/my%20file/%2Fpath/encoded.png"
+          }
+        ]
+      },
+      "stats": { "folders": 0, "files": 0, "downloads": 0, "generated": 0 }
+    },
+    "variables": { "%VERSION%": "1.2.3" },
+    "expectedPaths": [
+      "root",
+      "root/logo.png",
+      "root/raw.png",
+      "root/encoded.png"
+    ],
+    "expectedUrls": {
+      "root/logo.png": "https://cdn.example.com/1.2.3/logo.png",
+      "root/raw.png": "https://cdn.example.com/%UNDEFINED_TOKEN%/raw.png",
+      "root/encoded.png": "https://cdn.example.com/my%20file/%2Fpath/encoded.png"
+    }
+  },
+  {
     "name": "if with no off disabled values is falsy",
     "tree": {
       "root": {


### PR DESCRIPTION
Closes #133. Implements the agent brief posted there.

## What

- Native Plan expansion substitutes Variables in `url` (`Download` instructions now carry the resolved URL); the executor and diff preview inherit it automatically.
- Golden vector pins URL resolution on both Targets via a new optional `expectedUrls` fixture field: defined token resolved, undefined token left as-is, percent-encoding (`%20`, `%2F`) untouched.
- New Rust tests: plan unit test covers all three URL edges; diff preview asserts the substituted URL in both `url` and the `[Content from URL: …]` display.
- Web Target unchanged (already substituted) apart from the contract test asserting `expectedUrls`.

## Tests

Rust 265 + 49 + 46, shared 65, desktop 388, tsc clean.