### PR TITLE
refactor: give the Capability model a first-class registry

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -32,7 +32,7 @@ A platform implementation that turns a Schema into a structure: the native targe
 _Avoid_: platform, mode, backend.
 
 **Capability**:
-A discrete feature a Target may or may not support (file downloads, binary processing, hooks, watch, robust XML lexing). When a Target lacks a Capability it fails loudly, never silently producing a different result.
+A discrete feature a Target may or may not support (file downloads, binary processing, hooks, watch, robust XML lexing). When a Target lacks a Capability it fails loudly, never silently producing a different result. Failing loudly takes one of two declared forms: refusing the operation (a typed `CapabilityError`), or — where partial results are meaningful, as with post-create hooks — completing with an explicit warning. The per-Target support matrix lives in one frontend module, the Capability registry; adapters and UI gating both consult it.
 _Avoid_: feature flag, permission.
 
 ## Relationships

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -10,6 +10,7 @@ import { useAppStore } from "./store/appStore";
 import { useKeyboardShortcuts, useUpdater } from "./hooks";
 import { SHORTCUT_EVENTS } from "./constants/shortcuts";
 import { api } from "./lib/api";
+import { supports } from "./lib/capabilities";
 import type { Settings, ThemeMode, AccentColor } from "./types/schema";
 import { DEFAULT_SETTINGS } from "./types/schema";
 import { applyTheme, applyAccentColor } from "./utils/theme";
@@ -97,7 +98,7 @@ function App() {
   // Uses a ref to avoid re-running when checkForUpdates changes
   const hasCheckedForUpdates = useRef(false);
   useEffect(() => {
-    if (!api.isTauri() || !isInitialized || hasCheckedForUpdates.current) {
+    if (!supports("self-update") || !isInitialized || hasCheckedForUpdates.current) {
       return;
     }
 
@@ -151,8 +152,8 @@ function App() {
         setProjectName(newSettings.defaultProjectName);
       }
 
-      // Load plugins (Tauri only - sync from filesystem)
-      if (api.isTauri()) {
+      // Load plugins (sync from filesystem) where the Target supports them
+      if (supports("plugins")) {
         try {
           const plugins = await api.plugin.syncPlugins();
           setPlugins(plugins);

--- a/apps/desktop/src/components/Footer.tsx
+++ b/apps/desktop/src/components/Footer.tsx
@@ -1,5 +1,6 @@
 import { useAppStore } from "../store/appStore";
 import { api } from "../lib/api";
+import { supports } from "../lib/capabilities";
 import { UpdateBadge } from "./UpdateBadge";
 
 interface FooterProps {
@@ -42,7 +43,7 @@ export const Footer = ({ onOpenSettings, onOpenUpdateModal }: FooterProps) => {
             Settings
           </button>
         )}
-        {onOpenUpdateModal && api.isTauri() && (
+        {onOpenUpdateModal && supports("self-update") && (
           <UpdateBadge onClick={onOpenUpdateModal} />
         )}
       </div>

--- a/apps/desktop/src/components/RightPanel.tsx
+++ b/apps/desktop/src/components/RightPanel.tsx
@@ -18,6 +18,7 @@ import type { ResultSummary } from "../types/schema";
 import { SHORTCUT_EVENTS, getShortcutLabel } from "../constants/shortcuts";
 import * as creationRun from "../lib/creationRun";
 import type { CreationInputs, CreationReporter } from "../lib/creationRun";
+import { supports } from "../lib/capabilities";
 
 export const RightPanel = () => {
   const {
@@ -66,8 +67,8 @@ export const RightPanel = () => {
   const [undoLoading, setUndoLoading] = useState(false);
 
   const canExecute = schemaTree && outputPath && projectName;
-  const canWatch = schemaPath && schemaPath !== "new-schema" && !schemaPath.startsWith("template:") && api.isTauri();
-  const canUndo = canUndoCreation() && api.isTauri();
+  const canWatch = schemaPath && schemaPath !== "new-schema" && !schemaPath.startsWith("template:") && supports("watch");
+  const canUndo = canUndoCreation() && supports("undo");
 
   // Ref to hold the create handler for keyboard shortcut
   const handleCreateRef = useRef<(() => void) | null>(null);

--- a/apps/desktop/src/components/TeamLibrariesSection.tsx
+++ b/apps/desktop/src/components/TeamLibrariesSection.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback } from "react";
 import { useAppStore } from "../store/appStore";
 import { api } from "../lib/api";
-import { isTauri } from "../lib/platform";
+import { supports } from "../lib/capabilities";
 import {
   FolderIcon,
   PlusIcon,
@@ -144,8 +144,7 @@ export const TeamLibrariesSection = () => {
     addLog,
   } = useAppStore();
 
-  // Team libraries require file system access, only available in desktop app
-  const isDesktop = isTauri();
+  const isDesktop = supports("team-libraries");
 
   const [isExpanded, setIsExpanded] = useState(true);
   const [showAddModal, setShowAddModal] = useState(false);

--- a/apps/desktop/src/hooks/useUpdater.ts
+++ b/apps/desktop/src/hooks/useUpdater.ts
@@ -1,6 +1,6 @@
 import { useCallback, useRef } from "react";
 import { useAppStore } from "../store/appStore";
-import { api } from "../lib/api";
+import { supports, capabilityMessage } from "../lib/capabilities";
 
 type Update = Awaited<ReturnType<typeof import("@tauri-apps/plugin-updater").check>>;
 
@@ -24,9 +24,9 @@ export const useUpdater = (): UseUpdaterReturn => {
 
   const checkForUpdates = useCallback(
     async (silent = false) => {
-      if (!api.isTauri()) {
+      if (!supports("self-update")) {
         if (!silent) {
-          setUpdateError("Updates are only available in the desktop app");
+          setUpdateError(capabilityMessage("self-update"));
         }
         return;
       }
@@ -77,8 +77,8 @@ export const useUpdater = (): UseUpdaterReturn => {
   );
 
   const downloadAndInstall = useCallback(async () => {
-    if (!api.isTauri()) {
-      setUpdateError("Updates are only available in the desktop app");
+    if (!supports("self-update")) {
+      setUpdateError(capabilityMessage("self-update"));
       return;
     }
 
@@ -121,7 +121,7 @@ export const useUpdater = (): UseUpdaterReturn => {
   }, [setUpdateStatus, setUpdateProgress, setUpdateError]);
 
   const installAndRelaunch = useCallback(async () => {
-    if (!api.isTauri()) {
+    if (!supports("self-update")) {
       return;
     }
 

--- a/apps/desktop/src/lib/adapters/web/index.ts
+++ b/apps/desktop/src/lib/adapters/web/index.ts
@@ -44,6 +44,7 @@ import { validateVariables as validateVars, extractVariablesFromContent } from "
 import { toTokenKeys } from "../../../utils/variableName";
 import { WebTemplateImportExportAdapter } from "./template-io";
 import { scanZipToSchema } from "./zip-utils";
+import { CapabilityError } from "../../capabilities";
 
 // ============================================================================
 // Helper Functions
@@ -295,21 +296,8 @@ class WebStructureCreatorAdapter implements StructureCreatorAdapter {
     _items: CreatedItem[],
     _dryRun: boolean
   ): Promise<UndoResult> {
-    // Web mode doesn't support undo - the File System Access API doesn't support
-    // deletion reliably across all browsers
-    return {
-      logs: [{
-        log_type: "warning",
-        message: "Undo is not supported in web mode",
-        details: "Please use the desktop app for undo functionality",
-      }],
-      summary: {
-        files_deleted: 0,
-        folders_deleted: 0,
-        items_skipped: 0,
-        errors: 0,
-      },
-    };
+    // The File System Access API doesn't support deletion reliably across browsers
+    throw new CapabilityError("undo");
   }
 }
 
@@ -350,7 +338,7 @@ class WebValidationAdapter implements ValidationAdapter {
 
 class WebWatchAdapter implements WatchAdapter {
   async startWatch(_path: string): Promise<void> {
-    throw new Error("Watch mode is not supported in the web browser. Please use the desktop app for file watching functionality.");
+    throw new CapabilityError("watch");
   }
 
   async stopWatch(): Promise<void> {
@@ -379,7 +367,7 @@ class WebTeamLibraryAdapter implements TeamLibraryAdapter {
   }
 
   async addTeamLibrary(_name: string, _path: string): Promise<TeamLibrary> {
-    throw new Error("Team libraries are not supported in the web browser. Please use the desktop app for team library functionality.");
+    throw new CapabilityError("team-libraries");
   }
 
   async updateTeamLibrary(
@@ -391,15 +379,15 @@ class WebTeamLibraryAdapter implements TeamLibraryAdapter {
       isEnabled?: boolean;
     }
   ): Promise<TeamLibrary | null> {
-    throw new Error("Team libraries are not supported in the web browser. Please use the desktop app for team library functionality.");
+    throw new CapabilityError("team-libraries");
   }
 
   async removeTeamLibrary(_id: string): Promise<boolean> {
-    throw new Error("Team libraries are not supported in the web browser. Please use the desktop app for team library functionality.");
+    throw new CapabilityError("team-libraries");
   }
 
   async scanTeamLibrary(_libraryId: string): Promise<TeamTemplate[]> {
-    throw new Error("Team libraries are not supported in the web browser. Please use the desktop app for team library functionality.");
+    throw new CapabilityError("team-libraries");
   }
 
   async getTeamTemplate(_filePath: string): Promise<{
@@ -420,7 +408,7 @@ class WebTeamLibraryAdapter implements TeamLibraryAdapter {
       tags?: string[];
     }>;
   }> {
-    throw new Error("Team libraries are not supported in the web browser. Please use the desktop app for team library functionality.");
+    throw new CapabilityError("team-libraries");
   }
 
   async importTeamTemplate(
@@ -428,7 +416,7 @@ class WebTeamLibraryAdapter implements TeamLibraryAdapter {
     _filePath: string,
     _strategy: DuplicateStrategy
   ): Promise<TeamImportResult> {
-    throw new Error("Team libraries are not supported in the web browser. Please use the desktop app for team library functionality.");
+    throw new CapabilityError("team-libraries");
   }
 
   async getSyncLog(_libraryId: string | null, _limit: number): Promise<SyncLogEntry[]> {
@@ -451,19 +439,19 @@ class WebPluginAdapter implements PluginAdapter {
   }
 
   async installPlugin(_sourcePath: string): Promise<Plugin> {
-    throw new Error("Plugins are not supported in the web browser. Please use the desktop app for plugin functionality.");
+    throw new CapabilityError("plugins");
   }
 
   async uninstallPlugin(_id: string): Promise<boolean> {
-    throw new Error("Plugins are not supported in the web browser. Please use the desktop app for plugin functionality.");
+    throw new CapabilityError("plugins");
   }
 
   async enablePlugin(_id: string): Promise<Plugin | null> {
-    throw new Error("Plugins are not supported in the web browser. Please use the desktop app for plugin functionality.");
+    throw new CapabilityError("plugins");
   }
 
   async disablePlugin(_id: string): Promise<Plugin | null> {
-    throw new Error("Plugins are not supported in the web browser. Please use the desktop app for plugin functionality.");
+    throw new CapabilityError("plugins");
   }
 
   async getPluginSettings(_id: string): Promise<Record<string, unknown> | null> {
@@ -471,7 +459,7 @@ class WebPluginAdapter implements PluginAdapter {
   }
 
   async savePluginSettings(_id: string, _settings: Record<string, unknown>): Promise<Plugin | null> {
-    throw new Error("Plugins are not supported in the web browser. Please use the desktop app for plugin functionality.");
+    throw new CapabilityError("plugins");
   }
 
   async scanPlugins(): Promise<PluginManifest[]> {

--- a/apps/desktop/src/lib/adapters/web/structure-creator.ts
+++ b/apps/desktop/src/lib/adapters/web/structure-creator.ts
@@ -22,6 +22,7 @@ import {
   processZipWithVariables,
 } from "./zip-utils";
 import { isValidPublicUrl } from "./url-validation";
+import { capabilityWarning } from "../../capabilities";
 import {
   isTextFile,
   FETCH_TIMEOUT_MS,
@@ -156,13 +157,12 @@ export const createStructureFromTree = async (
     await executeNode(node, rootHandle, context, "", false);
   }
 
-  // Note: Hooks are not supported in web mode
+  // Degrade-with-warning: hooks are a missing Capability on the web Target,
+  // but partial results (the created structure) are still meaningful
   if (tree.hooks?.post_create && tree.hooks.post_create.length > 0) {
-    context.logs.push({
-      log_type: "warning",
-      message: "Post-create hooks are not supported in web mode",
-      details: `${tree.hooks.post_create.length} hook(s) skipped`,
-    });
+    context.logs.push(
+      capabilityWarning("hooks", `${tree.hooks.post_create.length} hook(s) skipped`)
+    );
   }
 
   return {

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -15,7 +15,7 @@
  *   const templates = await api.database.listTemplates();
  */
 
-import { isTauri, getCapabilities, type PlatformCapabilities } from "./platform";
+import { isTauri } from "./platform";
 import type { PlatformAdapter } from "./adapters/types";
 
 // Re-export types for convenience
@@ -38,13 +38,6 @@ export type {
 // Global adapter instance
 let adapter: PlatformAdapter | null = null;
 let initPromise: Promise<void> | null = null;
-
-/**
- * Get the platform capabilities.
- */
-export const capabilities = (): PlatformCapabilities => {
-  return getCapabilities();
-};
 
 /**
  * Check if the API has been initialized.
@@ -111,11 +104,6 @@ export const api = {
    * Check if initialized.
    */
   isInitialized,
-
-  /**
-   * Get platform capabilities.
-   */
-  capabilities,
 
   /**
    * Check if running in Tauri.

--- a/apps/desktop/src/lib/capabilities.test.ts
+++ b/apps/desktop/src/lib/capabilities.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("./platform", () => ({
+  getPlatform: vi.fn(),
+}));
+
+import { getPlatform } from "./platform";
+import {
+  supports,
+  requireCapability,
+  capabilityMessage,
+  capabilityWarning,
+  CapabilityError,
+  type Capability,
+} from "./capabilities";
+
+const mockGetPlatform = vi.mocked(getPlatform);
+
+const ALL: Capability[] = [
+  "watch",
+  "team-libraries",
+  "plugins",
+  "undo",
+  "hooks",
+  "self-update",
+];
+
+describe("capability matrix", () => {
+  it("the native Target supports every Capability", () => {
+    mockGetPlatform.mockReturnValue("tauri");
+    for (const cap of ALL) {
+      expect(supports(cap), cap).toBe(true);
+    }
+  });
+
+  it("the web Target refuses exactly these Capabilities", () => {
+    mockGetPlatform.mockReturnValue("web");
+    const refused = ALL.filter((cap) => !supports(cap));
+    expect(refused).toEqual(ALL);
+  });
+});
+
+describe("requireCapability", () => {
+  beforeEach(() => {
+    mockGetPlatform.mockReturnValue("web");
+  });
+
+  it("throws a CapabilityError naming the Capability", () => {
+    try {
+      requireCapability("team-libraries");
+      expect.unreachable("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(CapabilityError);
+      expect((e as CapabilityError).capability).toBe("team-libraries");
+      expect((e as CapabilityError).name).toBe("CapabilityError");
+      expect((e as CapabilityError).message).toContain("Team libraries");
+    }
+  });
+
+  it("passes silently on a supporting Target", () => {
+    mockGetPlatform.mockReturnValue("tauri");
+    expect(() => requireCapability("team-libraries")).not.toThrow();
+  });
+});
+
+describe("messages and warnings", () => {
+  it("every Capability has a user-facing message", () => {
+    for (const cap of ALL) {
+      expect(capabilityMessage(cap)).toBeTruthy();
+    }
+  });
+
+  it("capabilityWarning shapes a backend-style warning log", () => {
+    expect(capabilityWarning("hooks", "2 hook(s) skipped")).toEqual({
+      log_type: "warning",
+      message: "Post-create hooks are not supported in web mode",
+      details: "2 hook(s) skipped",
+    });
+  });
+});

--- a/apps/desktop/src/lib/capabilities.ts
+++ b/apps/desktop/src/lib/capabilities.ts
@@ -1,0 +1,85 @@
+/**
+ * Capability registry (see CONTEXT.md): the per-Target support matrix and the
+ * two declared forms of failing loudly — refusing the operation with a typed
+ * CapabilityError, or completing with an explicit warning where partial
+ * results are meaningful (post-create hooks).
+ *
+ * Adapters and UI gating both consult this module; it is the one answer to
+ * "what does this Target refuse to do?".
+ */
+
+import { getPlatform, type Platform } from "./platform";
+
+export type Capability =
+  | "watch"
+  | "team-libraries"
+  | "plugins"
+  | "undo"
+  | "hooks"
+  | "self-update";
+
+const MESSAGES: Record<Capability, string> = {
+  watch:
+    "Watch mode is not supported in the web browser. Please use the desktop app.",
+  "team-libraries":
+    "Team libraries are not supported in the web browser. Please use the desktop app.",
+  plugins:
+    "Plugins are not supported in the web browser. Please use the desktop app.",
+  undo: "Undo is not supported in the web browser. Please use the desktop app.",
+  hooks: "Post-create hooks are not supported in web mode",
+  "self-update": "Updates are only available in the desktop app",
+};
+
+const SUPPORT: Record<Platform, Record<Capability, boolean>> = {
+  tauri: {
+    watch: true,
+    "team-libraries": true,
+    plugins: true,
+    undo: true,
+    hooks: true,
+    "self-update": true,
+  },
+  web: {
+    watch: false,
+    "team-libraries": false,
+    plugins: false,
+    undo: false,
+    hooks: false,
+    "self-update": false,
+  },
+};
+
+export class CapabilityError extends Error {
+  readonly capability: Capability;
+
+  constructor(capability: Capability) {
+    super(MESSAGES[capability]);
+    this.name = "CapabilityError";
+    this.capability = capability;
+  }
+}
+
+/** Does the active Target support this Capability? */
+export const supports = (capability: Capability): boolean =>
+  SUPPORT[getPlatform()][capability];
+
+/** Refusal form: throw a typed CapabilityError when the Capability is missing. */
+export const requireCapability = (capability: Capability): void => {
+  if (!supports(capability)) {
+    throw new CapabilityError(capability);
+  }
+};
+
+/** The user-facing refusal message for a Capability. */
+export const capabilityMessage = (capability: Capability): string =>
+  MESSAGES[capability];
+
+/** Degrade form: a warning log entry for a skipped Capability. */
+export const capabilityWarning = (
+  capability: Capability,
+  details?: string
+): { log_type: "warning"; message: string; details?: string } => ({
+  log_type: "warning",
+  message: MESSAGES[capability],
+  details,
+});

--- a/apps/desktop/src/lib/platform.ts
+++ b/apps/desktop/src/lib/platform.ts
@@ -19,59 +19,10 @@ export const isWeb = (): boolean => {
 };
 
 /**
- * Check if the File System Access API is available.
- * This is required for web mode file operations.
- */
-export const hasFileSystemAccess = (): boolean => {
-  return (
-    typeof window !== "undefined" &&
-    "showOpenFilePicker" in window &&
-    "showDirectoryPicker" in window &&
-    "showSaveFilePicker" in window
-  );
-};
-
-/**
- * Check if IndexedDB is available.
- * This is required for web mode storage.
- */
-export const hasIndexedDB = (): boolean => {
-  return typeof window !== "undefined" && "indexedDB" in window;
-};
-
-/**
  * Get the current platform identifier.
  */
 export type Platform = "tauri" | "web";
 
 export const getPlatform = (): Platform => {
   return isTauri() ? "tauri" : "web";
-};
-
-/**
- * Platform capabilities object.
- */
-export interface PlatformCapabilities {
-  platform: Platform;
-  hasFileSystemAccess: boolean;
-  hasIndexedDB: boolean;
-  canExecuteHooks: boolean;
-  canDownloadFiles: boolean;
-  canProcessBinaryFiles: boolean;
-}
-
-export const getCapabilities = (): PlatformCapabilities => {
-  const platform = getPlatform();
-
-  return {
-    platform,
-    hasFileSystemAccess: platform === "tauri" || hasFileSystemAccess(),
-    hasIndexedDB: hasIndexedDB(),
-    // Hooks (shell commands) only work in Tauri
-    canExecuteHooks: platform === "tauri",
-    // File downloads work in both, but with different capabilities
-    canDownloadFiles: true,
-    // Binary file processing (DOCX, images with metadata, etc.) only in Tauri
-    canProcessBinaryFiles: platform === "tauri",
-  };
 };


### PR DESCRIPTION
## Summary

The domain **Capability** concept (CONTEXT.md, ADR-0002 — "asymmetry is declared, not drifted") had no code home. Reality was:

- 12 duplicated `throw new Error("...not supported...")` strings across the web adapter's watch/team-library/plugin stubs
- Web `undoStructure` quietly returning a warning result with `errors: 0` — a silent-ish success, violating the "fails loudly" invariant
- Hooks skipping with an inline-built warning
- UI gating via scattered `api.isTauri()` identity checks
- A `PlatformCapabilities` boolean struct (`canExecuteHooks`, `canDownloadFiles`, `canProcessBinaryFiles`) with **zero consumers** — dead code cited by ADR-0002 as the mechanism

This adds `apps/desktop/src/lib/capabilities.ts` — the **Capability registry**:

- `Capability` enum: `watch`, `team-libraries`, `plugins`, `undo`, `hooks`, `self-update` (only Capabilities with real consult sites; the enum grows when a site appears)
- Per-Target support matrix + `supports(cap)`
- Two declared forms of failing loudly: `CapabilityError` (typed, carries `.capability`) for refusal, `capabilityWarning()` for degrade-with-warning where partial results are meaningful (post-create hooks)
- `capabilityMessage()` for UI prose

## Changes

- Web adapter: 13 refusal sites → `throw new CapabilityError(...)` one-liners
- Web `undoStructure`: now throws `CapabilityError("undo")` — loud; UI already hides the undo button on web
- Hooks skip warning built by the registry (message unchanged)
- UI gates converted to `supports()`: `canWatch`, `canUndo`, TeamLibrariesSection, App plugin sync, useUpdater ×3, App auto-update check, Footer UpdateBadge. True identity sites (Footer platform label, web-only Settings/New Schema buttons, Tauri menu listeners) keep `isTauri()`
- Deleted dead code: `PlatformCapabilities`, `getCapabilities`, `hasFileSystemAccess`, `hasIndexedDB`, `api.capabilities`
- CONTEXT.md: Capability entry sharpened to bless the two refusal forms and name the registry

"What does the web Target refuse?" is now one file read, and a new Target (or a newly gained web Capability) is one matrix row.

## Testing

- 6 new registry tests: matrix per Target, `CapabilityError` shape, warning shape, message coverage
- Full desktop suite: 407/407 pass. `tsc --noEmit` clean. No stale references to deleted exports.

https://claude.ai/code/session_01LHyGMephAfEfrYLnv6EWpc