### PR TITLE
fix: complete the Variable map at one edge per Target (#140)

### DIFF
--- a/apps/desktop/src-tauri/src/commands/validation.rs
+++ b/apps/desktop/src-tauri/src/commands/validation.rs
@@ -178,8 +178,15 @@ pub fn cmd_generate_diff_preview(
     output_path: String,
     variables: HashMap<String, String>,
     overwrite: bool,
+    project_name: Option<String>,
 ) -> Result<DiffResult, String> {
-    generate_diff_preview(&tree, &output_path, &variables, overwrite)
+    generate_diff_preview(
+        &tree,
+        &output_path,
+        &variables,
+        overwrite,
+        project_name.as_deref(),
+    )
 }
 
 // ============================================================================

--- a/apps/desktop/src-tauri/src/diff_preview.rs
+++ b/apps/desktop/src-tauri/src/diff_preview.rs
@@ -11,6 +11,7 @@ use std::path::{Path, PathBuf};
 
 use crate::plan::{self, PlanContent, PlanKind, PlanNode, PlanNote};
 use crate::schema::SchemaTree;
+use crate::variables;
 use crate::types::{
     DiffAction, DiffHunk, DiffLine, DiffLineType, DiffNode, DiffNodeType, DiffResult, DiffSummary,
 };
@@ -36,8 +37,9 @@ const BINARY_THRESHOLD_DIVISOR: usize = 10;
 pub fn generate_diff_preview(
     tree: &SchemaTree,
     output_path: &str,
-    variables: &HashMap<String, String>,
+    user_variables: &HashMap<String, String>,
     overwrite: bool,
+    project_name: Option<&str>,
 ) -> Result<DiffResult, String> {
     let base_path = PathBuf::from(output_path);
     let mut summary = DiffSummary {
@@ -49,7 +51,11 @@ pub fn generate_diff_preview(
         warnings: Vec::new(),
     };
 
-    let structure_plan = plan::expand(tree, variables);
+    // Complete the Variable map exactly as creation does (ADR-0004), so the
+    // preview and the create it previews expand the same map.
+    let variables = variables::complete(user_variables, project_name, variables::now_local());
+
+    let structure_plan = plan::expand(tree, &variables);
 
     // Loud expansion errors/warnings surface as diff warnings; repeat
     // announcements and infos are execution-log concerns, not diff ones.
@@ -353,6 +359,46 @@ mod tests {
         }
     }
 
+    // The preview must expand the same Variable map creation does (ADR-0004):
+    // before this, diff preview injected no Built-in Variables at all, so a
+    // name using `%YEAR%` or `%PROJECT_NAME%` previewed as the literal token
+    // and then created with a value.
+    #[test]
+    fn diff_resolves_built_in_variables_like_creation() {
+        let t = tree(SchemaNode {
+            name: "root".to_string(),
+            node_type: "folder".to_string(),
+            children: Some(vec![
+                SchemaNode {
+                    name: "%YEAR%-notes.txt".to_string(),
+                    node_type: "file".to_string(),
+                    ..Default::default()
+                },
+                SchemaNode {
+                    name: "%PROJECT_NAME%.txt".to_string(),
+                    node_type: "file".to_string(),
+                    ..Default::default()
+                },
+            ]),
+            ..Default::default()
+        });
+
+        let temp = tempfile::tempdir().unwrap();
+        let result = generate_diff_preview(
+            &t,
+            temp.path().to_str().unwrap(),
+            &HashMap::new(),
+            false,
+            Some("my-project"),
+        )
+        .unwrap();
+
+        let children = result.root.children.as_ref().unwrap();
+        let year = chrono::Local::now().format("%Y").to_string();
+        assert_eq!(children[0].name, format!("{}-notes.txt", year));
+        assert_eq!(children[1].name, "my-project.txt");
+    }
+
     #[test]
     fn diff_matches_creation_semantics_for_repeat_edges() {
         // count above maximum: block skipped, loud warning — same as create
@@ -380,6 +426,7 @@ mod tests {
             temp.path().to_str().unwrap(),
             &HashMap::new(),
             false,
+            None,
         )
         .unwrap();
 
@@ -413,6 +460,7 @@ mod tests {
             temp.path().to_str().unwrap(),
             &HashMap::new(),
             true, // overwrite
+            None,
         )
         .unwrap();
 
@@ -442,7 +490,7 @@ mod tests {
 
         let temp = tempfile::tempdir().unwrap();
         let result =
-            generate_diff_preview(&t, temp.path().to_str().unwrap(), &variables, false).unwrap();
+            generate_diff_preview(&t, temp.path().to_str().unwrap(), &variables, false, None).unwrap();
 
         let file = &result.root.children.as_ref().unwrap()[0];
         assert_eq!(
@@ -493,7 +541,7 @@ mod tests {
 
         let temp = tempfile::tempdir().unwrap();
         let result =
-            generate_diff_preview(&t, temp.path().to_str().unwrap(), &variables, false).unwrap();
+            generate_diff_preview(&t, temp.path().to_str().unwrap(), &variables, false, None).unwrap();
 
         fn collect(node: &DiffNode, prefix: &str, out: &mut Vec<String>) {
             let path = if prefix.is_empty() {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@ pub mod team_library;
 pub mod templating;
 pub mod transforms;
 pub mod validation;
+pub mod variables;
 
 // New extracted modules
 pub mod commands;

--- a/apps/desktop/src-tauri/src/structure_creator.rs
+++ b/apps/desktop/src-tauri/src/structure_creator.rs
@@ -15,6 +15,7 @@ use crate::generators;
 use crate::plan::{self, PlanContent, PlanKind, PlanNode, PlanNote};
 use crate::schema::SchemaTree;
 use crate::transforms::substitute_variables;
+use crate::variables;
 use crate::types::{
     CreateResult, CreatedItem, HookResult, ItemType, LogEntry, ResultSummary, UndoResult,
     UndoSummary,
@@ -46,21 +47,8 @@ pub fn create_structure_from_tree(
     let mut hook_results: Vec<HookResult> = Vec::new();
     let mut created_items: Vec<CreatedItem> = Vec::new();
 
-    // Inject built-in variables, allowing user overrides
-    let mut all_variables = HashMap::new();
-    let now = chrono::Local::now();
-    all_variables.insert("%DATE%".to_string(), now.format("%Y-%m-%d").to_string());
-    all_variables.insert("%YEAR%".to_string(), now.format("%Y").to_string());
-    all_variables.insert("%MONTH%".to_string(), now.format("%m").to_string());
-    all_variables.insert("%DAY%".to_string(), now.format("%d").to_string());
-    // Inject %PROJECT_NAME% if provided
-    if let Some(name) = project_name {
-        all_variables.insert("%PROJECT_NAME%".to_string(), name.to_string());
-    }
-    // User-provided variables override built-ins
-    for (k, v) in variables.iter() {
-        all_variables.insert(k.clone(), v.clone());
-    }
+    // Complete the Variable map at the edge (ADR-0004), then expand
+    let all_variables = variables::complete(variables, project_name, variables::now_local());
 
     // Expand the schema into a Plan (pure), then execute it
     let structure_plan = plan::expand(tree, &all_variables);

--- a/apps/desktop/src-tauri/src/variables.rs
+++ b/apps/desktop/src-tauri/src/variables.rs
@@ -1,0 +1,140 @@
+//! Variable-map completion — the edge step every caller of `plan::expand`
+//! runs first (ADR-0004).
+//!
+//! A Variable map is *complete* when every Built-in Variable has a value and
+//! every key is a Variable token (`%NAME%`). Completion is pure: the caller
+//! supplies the wall-clock time, so the golden-vector contract can pin it at a
+//! fixed instant and `expand` stays deterministic.
+//!
+//! Keys are Variable tokens on both sides here. The Tauri adapter tokenizes at
+//! the IPC seam (ADR-0001), so the native Target never sees clean names.
+
+use std::collections::HashMap;
+
+use chrono::NaiveDateTime;
+
+/// Complete a Variable map: inject the Built-in Variables, then let
+/// user-supplied Variables override them.
+///
+/// `%PROJECT_NAME%` is injected only when a project name is supplied; the
+/// user's own `%PROJECT_NAME%` still wins over it.
+pub fn complete(
+    variables: &HashMap<String, String>,
+    project_name: Option<&str>,
+    now: NaiveDateTime,
+) -> HashMap<String, String> {
+    let mut completed = HashMap::new();
+
+    completed.insert("%DATE%".to_string(), now.format("%Y-%m-%d").to_string());
+    completed.insert("%YEAR%".to_string(), now.format("%Y").to_string());
+    completed.insert("%MONTH%".to_string(), now.format("%m").to_string());
+    completed.insert("%DAY%".to_string(), now.format("%d").to_string());
+
+    if let Some(name) = project_name {
+        completed.insert("%PROJECT_NAME%".to_string(), name.to_string());
+    }
+
+    // User-provided Variables override Built-in Variables.
+    for (key, value) in variables.iter() {
+        completed.insert(key.clone(), value.clone());
+    }
+
+    completed
+}
+
+/// The current wall-clock time in the machine's local zone — the instant every
+/// production caller of [`complete`] passes.
+pub fn now_local() -> NaiveDateTime {
+    chrono::Local::now().naive_local()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn at(text: &str) -> NaiveDateTime {
+        NaiveDateTime::parse_from_str(text, "%Y-%m-%dT%H:%M:%S").expect("valid wall-clock time")
+    }
+
+    fn vars(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn injects_every_built_in_variable() {
+        let completed = complete(&HashMap::new(), Some("my-project"), at("2026-08-10T14:30:00"));
+
+        assert_eq!(completed.get("%DATE%").unwrap(), "2026-08-10");
+        assert_eq!(completed.get("%YEAR%").unwrap(), "2026");
+        assert_eq!(completed.get("%MONTH%").unwrap(), "08");
+        assert_eq!(completed.get("%DAY%").unwrap(), "10");
+        assert_eq!(completed.get("%PROJECT_NAME%").unwrap(), "my-project");
+    }
+
+    #[test]
+    fn zero_pads_month_and_day() {
+        let completed = complete(&HashMap::new(), None, at("2026-03-05T09:00:00"));
+
+        assert_eq!(completed.get("%MONTH%").unwrap(), "03");
+        assert_eq!(completed.get("%DAY%").unwrap(), "05");
+        assert_eq!(completed.get("%DATE%").unwrap(), "2026-03-05");
+    }
+
+    #[test]
+    fn omits_project_name_when_absent() {
+        let completed = complete(&HashMap::new(), None, at("2026-08-10T14:30:00"));
+
+        assert!(!completed.contains_key("%PROJECT_NAME%"));
+    }
+
+    #[test]
+    fn user_variables_override_built_ins() {
+        let completed = complete(
+            &vars(&[("%DATE%", "custom-date"), ("%PROJECT_NAME%", "mine")]),
+            Some("supplied"),
+            at("2026-08-10T14:30:00"),
+        );
+
+        assert_eq!(completed.get("%DATE%").unwrap(), "custom-date");
+        assert_eq!(completed.get("%PROJECT_NAME%").unwrap(), "mine");
+    }
+
+    #[test]
+    fn keeps_user_variables_alongside_built_ins() {
+        let completed = complete(&vars(&[("%NAME%", "widget")]), None, at("2026-08-10T14:30:00"));
+
+        assert_eq!(completed.get("%NAME%").unwrap(), "widget");
+        assert_eq!(completed.get("%YEAR%").unwrap(), "2026");
+    }
+
+    // Golden-vector contract (ADR-0002): pins the Built-in Variable name set,
+    // their formats, and the user-override rule across both Targets.
+    #[test]
+    fn test_builtins_match_golden_contract() {
+        #[derive(serde::Deserialize)]
+        struct Case {
+            name: String,
+            now: String,
+            #[serde(rename = "projectName")]
+            project_name: Option<String>,
+            variables: HashMap<String, String>,
+            expected: HashMap<String, String>,
+        }
+
+        let fixture = include_str!("../../../../fixtures/builtins.json");
+        let cases: Vec<Case> = serde_json::from_str(fixture).expect("valid fixture JSON");
+        assert!(!cases.is_empty(), "builtins fixture must contain cases");
+
+        for case in cases {
+            let got = complete(&case.variables, case.project_name.as_deref(), at(&case.now));
+            assert_eq!(
+                got, case.expected,
+                "complete() case {:?}: expected {:?}, got {:?}",
+                case.name, case.expected, got
+            );
+        }
+    }
+}

--- a/apps/desktop/src/contract/builtins.contract.test.ts
+++ b/apps/desktop/src/contract/builtins.contract.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, it, expect } from "vitest";
+import { completeVariableMap } from "@structure-creator/shared";
+
+/**
+ * Golden-vector contract (ADR-0002). The builtins fixtures pin the Built-in
+ * Variable name set, their formats, and the user-override rule, consumed by
+ * both this web TS suite and the Rust suite.
+ *
+ * `now` is a local wall-clock string with no offset, so both languages read
+ * the same fields regardless of the machine's timezone.
+ */
+interface BuiltinsCase {
+  name: string;
+  now: string;
+  projectName: string | null;
+  variables: Record<string, string>;
+  expected: Record<string, string>;
+}
+
+const fixturePath = resolve(process.cwd(), "../../fixtures/builtins.json");
+const cases: BuiltinsCase[] = JSON.parse(readFileSync(fixturePath, "utf-8"));
+
+describe("built-in variable golden-vector contract", () => {
+  it("loads cases from the shared fixture", () => {
+    expect(cases.length).toBeGreaterThan(0);
+  });
+
+  it.each(cases)("$name", ({ now, projectName, variables, expected }) => {
+    const completed = completeVariableMap(
+      variables,
+      projectName ?? undefined,
+      new Date(now)
+    );
+    expect(completed).toEqual(expected);
+  });
+});

--- a/apps/desktop/src/lib/adapters/tauri/index.ts
+++ b/apps/desktop/src/lib/adapters/tauri/index.ts
@@ -325,9 +325,10 @@ class TauriStructureCreatorAdapter implements StructureCreatorAdapter {
     tree: SchemaTree,
     outputPath: string,
     variables: Record<string, string>,
-    overwrite: boolean
+    overwrite: boolean,
+    projectName?: string
   ): Promise<DiffResult> {
-    return _unwrap(await commands.cmdGenerateDiffPreview(tree, outputPath, toTokenKeys(variables), overwrite)) as DiffResult;
+    return _unwrap(await commands.cmdGenerateDiffPreview(tree, outputPath, toTokenKeys(variables), overwrite, projectName ?? null)) as DiffResult;
   }
 
   async undoStructure(

--- a/apps/desktop/src/lib/adapters/types.ts
+++ b/apps/desktop/src/lib/adapters/types.ts
@@ -239,12 +239,16 @@ export interface StructureCreatorAdapter {
 
   /**
    * Generate a diff preview showing what would be created/changed.
+   *
+   * `projectName` feeds the same Variable-map completion creation uses, so the
+   * preview and the create it previews expand the same map (ADR-0004).
    */
   generateDiffPreview(
     tree: SchemaTree,
     outputPath: string,
     variables: Record<string, string>,
-    overwrite: boolean
+    overwrite: boolean,
+    projectName?: string
   ): Promise<DiffResult>;
 
   /**

--- a/apps/desktop/src/lib/adapters/web/index.ts
+++ b/apps/desktop/src/lib/adapters/web/index.ts
@@ -41,7 +41,7 @@ import { WebFileSystemAdapter, getHandleRegistry } from "./filesystem";
 import { parseSchema, exportSchemaXml, scanDirectoryToSchema } from "./schema-parser";
 import { createStructureFromTree, generateDiffPreview } from "./structure-creator";
 import { validateVariables as validateVars, extractVariablesFromContent } from "./transforms";
-import { toTokenKeys } from "@structure-creator/shared";
+import { completeVariableMap, toTokenKeys } from "@structure-creator/shared";
 import { WebTemplateImportExportAdapter } from "./template-io";
 import { scanZipToSchema } from "./zip-utils";
 import { CapabilityError } from "../../capabilities";
@@ -89,43 +89,6 @@ const extractExtendsFromXml = (xmlContent: string): string | undefined => {
   } catch {
     return undefined;
   }
-};
-
-/**
- * Inject built-in date variables into a variables object.
- * Built-in variables are injected first, then user-provided variables override them.
- * Matches the Tauri adapter behavior in lib.rs.
- */
-const injectBuiltInVariables = (
-  variables: Record<string, string>,
-  projectName?: string
-): Record<string, string> => {
-  const now = new Date();
-  const year = now.getFullYear().toString();
-  const month = (now.getMonth() + 1).toString().padStart(2, "0");
-  const day = now.getDate().toString().padStart(2, "0");
-
-  // Start with built-in variables
-  const allVariables: Record<string, string> = {
-    "%DATE%": `${year}-${month}-${day}`,
-    "%YEAR%": year,
-    "%MONTH%": month,
-    "%DAY%": day,
-  };
-
-  // Inject %PROJECT_NAME% if provided
-  if (projectName) {
-    allVariables["%PROJECT_NAME%"] = projectName;
-  }
-
-  // User-provided variables override built-ins. They arrive as clean
-  // canonical names (ADR-0001); the web engine looks variables up by their
-  // token form, so tokenize the keys at this adapter boundary.
-  for (const [key, value] of Object.entries(toTokenKeys(variables))) {
-    allVariables[key] = value;
-  }
-
-  return allVariables;
 };
 
 // ============================================================================
@@ -260,8 +223,12 @@ class WebStructureCreatorAdapter implements StructureCreatorAdapter {
       );
     }
 
-    // Inject built-in variables (date, project name), allowing user overrides
-    const allVariables = injectBuiltInVariables(options.variables, options.projectName);
+    // Complete the Variable map at the edge (ADR-0004), then expand
+    const allVariables = completeVariableMap(
+      options.variables,
+      options.projectName,
+      new Date()
+    );
 
     return createStructureFromTree(
       tree,
@@ -276,7 +243,8 @@ class WebStructureCreatorAdapter implements StructureCreatorAdapter {
     tree: SchemaTree,
     _outputPath: string,
     variables: Record<string, string>,
-    overwrite: boolean
+    overwrite: boolean,
+    projectName?: string
   ): Promise<DiffResult> {
     const rootHandle = getHandleRegistry().getRootHandle();
     if (!rootHandle) {
@@ -286,8 +254,9 @@ class WebStructureCreatorAdapter implements StructureCreatorAdapter {
       );
     }
 
-    // Inject built-in date variables for consistent preview
-    const allVariables = injectBuiltInVariables(variables);
+    // Complete the Variable map exactly as creation does, so the preview and
+    // the create it previews expand the same map.
+    const allVariables = completeVariableMap(variables, projectName, new Date());
 
     return generateDiffPreview(tree, rootHandle, allVariables, overwrite);
   }

--- a/apps/desktop/src/lib/creationRun.test.ts
+++ b/apps/desktop/src/lib/creationRun.test.ts
@@ -118,7 +118,9 @@ describe("preview", () => {
 
     expect(outcome).toEqual({ ok: true, diff });
     expect(reporter.onDiffStart).toHaveBeenCalledOnce();
-    expect(mockDiffPreview).toHaveBeenCalledWith(tree, "/out", { NAME: "x" }, false);
+    // projectName reaches the preview so it completes the same Variable map
+    // creation does (ADR-0004)
+    expect(mockDiffPreview).toHaveBeenCalledWith(tree, "/out", { NAME: "x" }, false, "proj");
   });
 
   it("stops at validation failure without computing the diff", async () => {

--- a/apps/desktop/src/lib/creationRun.ts
+++ b/apps/desktop/src/lib/creationRun.ts
@@ -234,7 +234,8 @@ export const preview = async (
       inputs.tree,
       inputs.outputPath,
       varsMap,
-      inputs.overwrite
+      inputs.overwrite,
+      inputs.projectName
     );
     return { ok: true, diff };
   } catch (e) {

--- a/apps/desktop/src/lib/generated/commands.ts
+++ b/apps/desktop/src/lib/generated/commands.ts
@@ -207,9 +207,9 @@ async cmdValidateSchema(content: string, variables: { [key in string]: string })
     else return { status: "error", error: e  as any };
 }
 },
-async cmdGenerateDiffPreview(tree: SchemaTree, outputPath: string, variables: { [key in string]: string }, overwrite: boolean) : Promise<Result<DiffResult, string>> {
+async cmdGenerateDiffPreview(tree: SchemaTree, outputPath: string, variables: { [key in string]: string }, overwrite: boolean, projectName: string | null) : Promise<Result<DiffResult, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("cmd_generate_diff_preview", { tree, outputPath, variables, overwrite }) };
+    return { status: "ok", data: await TAURI_INVOKE("cmd_generate_diff_preview", { tree, outputPath, variables, overwrite, projectName }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };

--- a/fixtures/builtins.json
+++ b/fixtures/builtins.json
@@ -1,0 +1,78 @@
+[
+  {
+    "name": "injects every built-in alongside user variables",
+    "now": "2026-08-10T14:30:00",
+    "projectName": "my-project",
+    "variables": { "%NAME%": "widget" },
+    "expected": {
+      "%DATE%": "2026-08-10",
+      "%YEAR%": "2026",
+      "%MONTH%": "08",
+      "%DAY%": "10",
+      "%PROJECT_NAME%": "my-project",
+      "%NAME%": "widget"
+    }
+  },
+  {
+    "name": "zero-pads month and day",
+    "now": "2026-03-05T09:00:00",
+    "projectName": "padded",
+    "variables": {},
+    "expected": {
+      "%DATE%": "2026-03-05",
+      "%YEAR%": "2026",
+      "%MONTH%": "03",
+      "%DAY%": "05",
+      "%PROJECT_NAME%": "padded"
+    }
+  },
+  {
+    "name": "omits PROJECT_NAME when no project name is supplied",
+    "now": "2026-08-10T14:30:00",
+    "projectName": null,
+    "variables": {},
+    "expected": {
+      "%DATE%": "2026-08-10",
+      "%YEAR%": "2026",
+      "%MONTH%": "08",
+      "%DAY%": "10"
+    }
+  },
+  {
+    "name": "reads wall-clock time, never a UTC-shifted date",
+    "now": "2026-01-01T00:30:00",
+    "projectName": null,
+    "variables": {},
+    "expected": {
+      "%DATE%": "2026-01-01",
+      "%YEAR%": "2026",
+      "%MONTH%": "01",
+      "%DAY%": "01"
+    }
+  },
+  {
+    "name": "reads wall-clock time near the end of a day",
+    "now": "2025-12-31T23:45:00",
+    "projectName": null,
+    "variables": {},
+    "expected": {
+      "%DATE%": "2025-12-31",
+      "%YEAR%": "2025",
+      "%MONTH%": "12",
+      "%DAY%": "31"
+    }
+  },
+  {
+    "name": "user variables override built-ins",
+    "now": "2026-08-10T14:30:00",
+    "projectName": "supplied",
+    "variables": { "%DATE%": "custom-date", "%PROJECT_NAME%": "mine" },
+    "expected": {
+      "%DATE%": "custom-date",
+      "%YEAR%": "2026",
+      "%MONTH%": "08",
+      "%DAY%": "10",
+      "%PROJECT_NAME%": "mine"
+    }
+  }
+]

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -10,5 +10,8 @@ export * from './variableName';
 // Variable transforms + substitution (port of the Rust transforms.rs)
 export * from './transforms';
 
+// Variable-map completion, the edge that feeds the Plan (ADR-0004)
+export * from './variables';
+
 // The web Target's Plan module (ADR-0004)
 export * from './plan';

--- a/packages/shared/src/variables.ts
+++ b/packages/shared/src/variables.ts
@@ -1,0 +1,49 @@
+/**
+ * Variable-map completion — the edge step every caller of `expand` runs first
+ * (ADR-0004).
+ *
+ * A Variable map is *complete* when every Built-in Variable has a value and
+ * every key is a Variable token (`%NAME%`). Completion is pure: the caller
+ * supplies the wall-clock time, so the golden-vector contract can pin it at a
+ * fixed instant and `expand` stays deterministic.
+ *
+ * Input keys are clean Variable names (ADR-0001); this is the web Target's
+ * outbound edge, so it tokenizes them on the way out.
+ */
+
+import { toTokenKeys } from "./variableName";
+
+/**
+ * Complete a Variable map: inject the Built-in Variables, then let
+ * user-supplied Variables override them.
+ *
+ * `%PROJECT_NAME%` is injected only when a project name is supplied; the
+ * user's own `%PROJECT_NAME%` still wins over it.
+ */
+export const completeVariableMap = (
+  variables: Record<string, string>,
+  projectName: string | undefined,
+  now: Date
+): Record<string, string> => {
+  const year = now.getFullYear().toString();
+  const month = (now.getMonth() + 1).toString().padStart(2, "0");
+  const day = now.getDate().toString().padStart(2, "0");
+
+  const completed: Record<string, string> = {
+    "%DATE%": `${year}-${month}-${day}`,
+    "%YEAR%": year,
+    "%MONTH%": month,
+    "%DAY%": day,
+  };
+
+  if (projectName) {
+    completed["%PROJECT_NAME%"] = projectName;
+  }
+
+  // User-provided Variables override Built-in Variables.
+  for (const [key, value] of Object.entries(toTokenKeys(variables))) {
+    completed[key] = value;
+  }
+
+  return completed;
+};


### PR DESCRIPTION
Closes #140.

## The bug

ADR-0004 requires a **complete Variable map** to reach `expand`, but named that edge without giving it a module — so every caller wrote its own, and they drifted:

| Caller | Built-in Variables injected |
|---|---|
| Native create | all five |
| Native diff preview | **none** |
| Web create | all five |
| Web diff preview | dates only, **no `%PROJECT_NAME%`** |

A schema with `%DATE%` in a name previewed as the literal `%DATE%` on the native Target and created as a date. The preview lied about what create would do.

## The fix

One completion module per Target:

- `apps/desktop/src-tauri/src/variables.rs` — `complete(vars, project_name, now)`
- `packages/shared/src/variables.ts` — `completeVariableMap(vars, projectName, now)`

Both diff-preview paths now call it, and `projectName` is plumbed through `cmd_generate_diff_preview`, the `StructureCreatorAdapter` interface, both adapters, and `creationRun.preview` — which now passes the same value `creationRun.create` already did. Preview and create expand identical maps.

Key forms follow ADR-0001: TS is clean-in/token-out (it absorbs the `toTokenKeys` call the web adapter used to make inline); Rust is token-in/token-out, because the brand stops at the IPC seam and the Tauri adapter has already tokenized. No strip-then-rewrap round trip was added to make the signatures match.

## One deviation from the plan

The issue specified fixture `now` as ISO-8601 with an explicit offset. That doesn't work across the two languages: a JS `Date` renders `getFullYear()`/`getMonth()` in the *runner's* zone, so a `+10:00` fixture yields different expected values per machine, while Rust's `DateTime<FixedOffset>` honours the offset.

`now` is instead a local wall-clock string (`"2026-08-10T14:30:00"`), which both languages read identically and machine-independently, and `complete` takes wall-clock time (`NaiveDateTime` / `Date`). The local-vs-UTC decision moves out of the pinned function to the one-line call site — `variables::now_local()` in Rust, `new Date()` in TS.

## Contract

New `fixtures/builtins.json`, consumed by the Rust suite (`include_str!`) and the TS suite (`readFileSync`), same as the existing five. Six cases: the full name set alongside user variables, zero-padded month and day, `%PROJECT_NAME%` omitted when absent, two wall-clock reads at day boundaries, and user variables overriding built-ins.

Plus `diff_resolves_built_in_variables_like_creation` in `diff_preview.rs` — a preview of `%YEAR%-notes.txt` and `%PROJECT_NAME%.txt` must come back resolved. It fails against the previous code.

## Tests

- Rust: 272 passed (was 271; the codegen binding assertion regenerated for the new command parameter)
- TS: 396 passed across 23 files, `tsc --noEmit` clean

## Not in scope

- #142 — collapsing the five duplicated Built-in Variable name lists
- #144 — warning when a user Variable shadows a Built-in Variable